### PR TITLE
Dev UX: disable API rate-limit middleware in dev to prevent 429 spam …

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,12 +32,14 @@ def create_app() -> FastAPI:
         response = await call_next(request)
         return response
 
-    # Simple per-IP rate limit (very basic, in-memory)
+    # Simple per-IP rate limit (very basic, in-memory). Disabled in dev.
     from starlette.responses import JSONResponse
     rate_counts: dict[str, int] = {}
 
     @app.middleware("http")
     async def rate_limit(request: Request, call_next):
+        if settings.environment and settings.environment.lower() == "dev":
+            return await call_next(request)
         ip = request.client.host if request.client else "unknown"
         rate_counts[ip] = rate_counts.get(ip, 0) + 1
         if rate_counts[ip] > 200:


### PR DESCRIPTION
…in HealthIndicator polling.