### PR TITLE
Fix week 22 meeting issues: auth caching, location prefs, role refresh

### DIFF
--- a/backend/app/routers/gap_analysis.py
+++ b/backend/app/routers/gap_analysis.py
@@ -24,6 +24,7 @@ class GapAnalysisPreferences(BaseModel):
     minimum_salary: str = ""
     job_search_status: str = ""
     state: Optional[str] = None
+    metro_areas: List[str] = Field(default_factory=list)
     user_mode: str = "job-seeker"
 
 
@@ -829,11 +830,24 @@ def _deterministic_rank(
         if loc_text:
             loc_prefs.append(loc_text)
         loc_floor = str(preferences.state or "").strip()
+        metro_areas = [x.strip() for x in _norm_list(getattr(preferences, "metro_areas", None)) if str(x).strip()]
         job_loc = _job_location(j)
-        if loc_prefs or loc_floor:
+        if loc_prefs or loc_floor or metro_areas:
             jl = (job_loc or "").lower()
-            # If user picked a state, require it when job is onsite/hybrid and location is known.
-            if loc_floor and job_work in {"onsite", "hybrid"} and jl and loc_floor.lower() not in jl:
+            # Generic US locations like "United States" or "US" are never a mismatch
+            # for users who selected a US state or metro area.
+            jl_is_generic_us = jl in {"united states", "us", "usa", "u.s.", "u.s.a.", "united states of america", ""}
+            # Check metro areas first (new system)
+            if metro_areas and job_work in {"onsite", "hybrid"} and jl and not jl_is_generic_us:
+                metro_match = any(m.lower() in jl or jl in m.lower() for m in metro_areas)
+                # Also check if the state abbreviation from any metro matches
+                if not metro_match:
+                    metro_states = {m.split(", ")[-1].strip().lower() for m in metro_areas if ", " in m}
+                    metro_match = any(st in jl for st in metro_states)
+                if not metro_match:
+                    pref_gaps.append(f"Location preference mismatch: your preferred metro areas are {', '.join(metro_areas[:3])}, but this job appears to be in {job_loc or 'an unspecified location'}.")
+            # Fall back to old state check (backward compat)
+            elif loc_floor and job_work in {"onsite", "hybrid"} and jl and not jl_is_generic_us and loc_floor.lower() not in jl:
                 pref_gaps.append(f"Location preference mismatch: you selected {loc_floor}, but this job appears to be in {job_loc or 'an unspecified location'}.")
 
 

--- a/backend/app/routers/job_preferences.py
+++ b/backend/app/routers/job_preferences.py
@@ -33,6 +33,7 @@ class JobPreferences(BaseModel):
     minimum_salary: str
     job_search_status: str
     state: Optional[str] = None
+    metro_areas: List[str] = []
     user_mode: str = "job-seeker"  # job-seeker or recruiter
 
 class JobPreferencesResponse(BaseModel):

--- a/context/week_22/Untitled
+++ b/context/week_22/Untitled
@@ -1,0 +1,672 @@
+
+Roleferry 3/19/26
+All right I’m transcribing. So let’s go ahead and see how Role Fairy looks I haven’t had any.
+You ready
+Any thought space to really think about it this week, but, um, hold on.
+Are you ready for it? I wasn’t, uh.
+Yeah, yeah, yeah. Uh, do you want to you want to jump on, uh, the screen share or whatever?
+Let me just get some water. Possibly get some water.
+Here.
+I didn’t think you’d be ready so quickly.
+No, it’s—
+Uh, let’s see here.
+Seconds is is hours over here. Okay, so let me see, um,
+oh, we have one set up for, like, half an hour. I’m basically late, aren’t I? Did you schedule that one?
+Um,
+I don’t know I don’t know what I did.
+I guess we were supposed to meet, like, 30 minutes ago. Sorry.
+Why joined it There’s one on my calendar that says the 7:30 Role Fairy weekly review. It started 30 minutes ago.
+It’s good
+So I just joined. I’m in there.
+Hi. I want to jump on in about two minutes.
+What now
+I’m going to jump in in, like, two minutes. I’m just talking about the bathroom real quick.
+Yeah, go for it All right See you there. Bye.
+Okay.
+All right I’m going to go ahead and walk through the Role Fairy screens.
+So I am on the login screen of Role Fairy, and I am using my username, and my login to get in. I have now logged into Role Fairy. I see the role preferences screen. Everything is collapsed as desired. That looks good. My minimum expected salary is $200,000 in there.
+I have things checked. That looks fine. I’m probably fine with aerospace, so I’m going to add that as one of my industries.
+It says, “What industries are you exciting for you?” Um,
+I’ll go ahead and click all sizes of companies so that I can see the job roles that might come up when I do that.
+Let’s see.
+Okay.
+Yeah. All right
+All right.
+All right. So are you still there?
+Sorry Closed the wrong window.
+All right Still there?
+You’re welcome.
+Yeah, you’re back Sorry about that. Yeah, so, uh, I was, uh, just looking at the screen here.
+Um.
+Mm-hmm.
+All right
+Yeah.
+So I logged in I’m on the first screen. Making sure these things are correct.
+Oh, I’m trying to get everything. I’m not there yet, swear.
+Windows open here.
+Okay.
+I don’t know You delete, delete.
+Is that down? Is this down?
+Um, is this down?
+Okay.
+All right Um, okay. And then we’re going to yeah, looking for my window.
+Uh, okay. Zoom out.
+Okay. I’m in. I’m in.
+All righty.
+Okay. How about you share? That way,
+um I was am I sharing? I’m not sharing, of course.
+No, you’re sharing.
+Okay.
+Um, okay.
+All right.
+Okay.
+All right Um,
+so I think that we’ve gotten really far here, but, um,
+let’s see. Maybe I’ll go to, um,
+do one start from the beginning?
+Yeah, go ahead. Start from the beginning. Talk it through.
+Yeah.
+Okay.
+All right
+Processing it.
+The guy at work’s asking me questions. Oh, we got problems?
+HTTP 500 Let me see what happened.
+No, try look at the dev tools.
+I mean, like, you know, left, right click, and
+I was going to give you another file.
+Yeah, just try, try to right click it.
+And then.
+New page source
+Yeah, view the source and see what errors there are.
+Oh, inspect, inspect. Okay.
+Are there errors Click on the console, not elements. Console, where the red X wasn’t there. Over on the here we go, right there. Console.
+Oh, console.
+There you go.
+You just copy and paste all that into the chat for me.
+Hmm.
+Um,
+actually,
+okay.
+I’ve been using Claude to, um,
+kind of replace Claude.
+Oh, yeah.
+Yeah.
+Claude is getting crazy.
+So I just um put another resume in. It worked better.
+My resume I put in there. Got a little funky.
+Sorry, Nana. I’m super, like, getting messages from this guy at work. Um,
+so I’m just kind of trying to finish dealing with him. All right. Um,
+I mean, I just have to do it So let’s see. Um,
+where is shouldn’t be working at 8:00 at night, man.
+Yeah, I can’t be working. I don’t think you’re going to be working at night. That’s why I called you.
+Okay.
+No, I’ll be done with him in a sec. I just need to just need to deal with him.
+One second here.
+Okay.
+I’m going to send this guy a document and then I’ll give him my full attention.
+Um, tell him to leave me on for a while because I’ll be, like, gone. Okay. Um,
+okay. I’m going to show him my status as offline so this guy stops messaging me because it’s impossible to multitask right now.
+Appear offline.
+Yeah.
+Now I am invisible, and he cannot talk to me. All right. And I’m going to close Teams, so that’ll help too. Okay.
+Sorry about that Um, back to Role Fairy. Okay. So did you get past the error you were having?
+Um, yeah. I put it in a different resume, and it seemed to work out.
+Oh, okay. Okay. Well, then if you don’t have it with a I don’t know what happened. Maybe it was just a glitch.
+We don’t want our clients to
+Yeah. It seems to work with some resume.
+So this, uh, so I was testing out the different resumes.
+Okay.
+Um, but yeah, I’m using, uh, Role Fairy now.
+Okay.
+Um,
+roles. So the roles?
+All right How’s that working?
+I think the I think the roles, uh, I didn’t update the keywords, the different resume.
+It might automatically refresh. Just it might be a little delayed.
+Remember it might remember it did last time.
+So.
+Yeah. That’s the real I really want to test that in different resumes.
+Oh, yeah. One thing we talked about was, like, creating other accounts. Like,
+like a different resume, and because you know what? It’s going to kind of.
+You know what I’m going to do that I’m actually going to do that I’m going to create a new account.
+It’s like caching old stuff. That way, you don’t have to worry about it. But you can just create maybe use it based on one of the resumes you have.
+This little estimated name. Like, do you have a resume that’s, like, for a client you can create a fake thing for him?
+Yeah, yeah, yeah, yeah. I’m just going to make up an email address.
+Well, I think you’re going to need an email address because it sends you a confirmation, doesn’t it?
+Yeah. I’m not making up, but you know, using other ones.
+Okay.
+Is John Jacobson a client You have the resume?
+No, it’s just a fake name that I’ve used.
+Okay. Do you have a resume that says John Jacobson, though?
+No. So I use a name that actually matched in the resume.
+Yeah. That’s what I was thinking because that way, it’s not going to be confusing later if it’s working. I don’t want there to be confusion about whether the app’s working. If you, uh.
+Okay. I’ll use another card. Robert. What’s his last name? Let me just try to spell his last name.
+All right Let’s see here. Um,
+let’s change.
+Let’s see.
+Um, whatever resume you find and make the account for that guy. Email doesn’t matter, but, uh, yeah.
+Yeah. The way weird names show up, you’re not thinking it’s the app’s fault or vice versa.
+Yeah, yeah.
+Or if it is the app’s fault, you’ll know it.
+Um,
+my email address My phone number Yeah. Password.
+Email. Password.
+I see some match. It has all right. Wait. It’s in I’m in the same. I literally put Robert in, and now I have David again.
+All right You’re logged into that’s weird. So just for the transcript, so you logged into a different account, and it still says, “Hi, David.”
+So it’s going off of your IP address or something. Instead of your login.
+Or maybe some information on your computer, maybe.
+No, it’s crazy.
+Yeah. Maybe you didn’t log did you log in or did you, like,
+go
+I was logged out because that was crazy.
+Yeah. She said Robert
+Yeah.
+Let’s see if I got a confirmation email Tuesday that the email address.
+Hmm.
+I didn’t get a confirmation email to the email address.
+Well, that’s not good Let’s test other screens. I’ll go over that as fixed.
+Like I said, it might be able to fix anything real-time for like two days, so.
+Okay. So yeah. We just want to know that the, uh, when you log in under new account, it’s still having my old account in there.
+Yeah.
+Yeah. David.
+And it’s not created a new, uh, user account for a different person. Put a different name, and it’s still saying, “Hi, David,” at the top right, so.
+Hi, David. And it has all my old information.
+And it’s saved it’s somehow all his cached could be your browser.
+It’s got to be your browser. Caching. Can you, like, use a different browser?
+I can use a different browser.
+I just got yeah, it’s got all your, uh, cached stuff. If you log into a different account, it shouldn’t have cached stuff in there.
+I’m using Google Chrome instead of uh, Microsoft, uh, Explorer.
+All right Log out.
+First name is my main one.
+I’m going to make it different
+Can you clear the cache up there in your settings too?
+Okay. Settings.
+Yeah.
+Um,
+that wasn’t there.
+Yeah. Like, clear the cache.
+Settings.
+System You see my screen, right?
+Yeah, I do now I couldn’t see the dropdown from before. Go to, like.
+I’m on settings over here. What am I supposed to go?
+I’m going to go to privacy and security.
+Okay.
+And then, um, delete browsing data, history, cookies, cache, and more.
+Okay.
+And then just delete data.
+Okay.
+There you go.
+There you go. You should be good now
+All right So now.
+Close that
+I am
+Close your tab.
+Okay. Now I’m back on the screen.
+You’re there. Now log in To the one you just.
+I’m logging into the new account. Should say Robert.
+Yeah. So
+one thing we should fix, though, is we don’t want catch cached, um,
+screens to show up for you if you log into a different account. So that’s a it’s still a bug that needs to be fixed.
+But for now it’ll it shouldn’t be happening anymore. If it is, then there’s another problem. I don’t think it is.
+But it is. So there’s another problem.
+Let’s just log in.
+Okay. That’s weird.
+Should say Robert
+Yeah.
+You did you did put Robert in there, right?
+Yeah. Robert’s the name of the account.
+Well, it’s just a bug. It needs to be fixed. Let’s not spend any more time on it because it’s just a bug. I’ll fix it.
+Okay.
+I mean, it’s it’s a big deal, but it’s not a big-time thing. It’s like we can move on. I’ll fix it. It’s good that we noted it. Now I can fix it.
+Okay. All right
+Mm-hmm.
+Sorry that that is there. But it is what it is.
+There’s another good reason we’re testing that, right? Like, we we just discovered another bug by by doing that.
+There’s some, like, really weird IP caching happening that I don’t understand, but. But yeah. I’ll fix it.
+Okay. Robert Okay.
+Looks good.
+Um, next.
+I’m going to go through this whole personnel thing.
+Just click something. Click them all just so you’ve had it there. They don’t have to be accurate.
+Just click them all
+Yeah. I mean, as long as it matches to whatever the type is.
+Doesn’t really matter since we’re not actually trying to find him a job through here yet necessarily. Although he probably wouldn’t mind, but.
+It’s going to say type psychopath. Job recommended cannibal.
+You’re not doing that I think you got to put you have to do the four temperaments one first.
+Oh, okay.
+Unless I didn’t, uh,
+uh, no, I didn’t put them up on it. Um, press this button.
+Oh.
+The dropdown
+But okay.
+Okay.
+So we got to continue.
+Now we can role search The thing is role search. Now it should not have any of my um,
+information. Okay. It doesn’t. Okay. Good.
+Okay.
+Something.
+Splunk
+I don’t know. Yeah.
+Um, let’s see. I’m not sure. Executive. Chief economist. This is the.
+Why is it not in match It says preferences. Maybe I got to redo this.
+What’s up Yeah.
+Technical engineering. Missionary engineering.
+Um,
+that’s not perfect. Managing.
+Is my brain working? Technical engineering. Yes.
+Patient training. Pharmaceutical industry.
+Those are the two kind of ones we’d be interested in.
+Platform It has to be um, so you could do remote hard or person. And let’s see.
+No, categories we’re looking for.
+What’s on?
+Okay.
+Yeah. The longer you’re unemployed, if you like need a job, it just drops and drops and drops. You’re like, “Oh, I’ll take whatever I can.” So.
+Yeah. Just another guy was doing it the other day. It was like, uh, he’s like, “We’re trying to get out of like auto dealerships. Car dealerships.
+Um,
+and he’s looking, looking, looking and eventually just took another job at the car dealership.”
+Yeah.
+Well, that’s where you’re for they’re going to look at your experience. They’re going to want to know what you’re going to do stuff.
+Okay. So jobs that okay. So um,
+we got keywords. We’re trying to get the matches. And then what we did what I did just before was I updated the preferences section.
+Oh, okay.
+Because he doesn’t want any roles within sales.
+It’s roles within tech.
+So you’re going to you’re going to put something in negative keywords for sales?
+Well, we’re getting a lot of sales roles. So like account executive. We’re getting a lot of sales roles.
+Account executive. So down under negative keywords, put sales.
+There you go.
+I think there’s some kind of new yeah.
+Dude, I know guys’ system was good, man. You can’t deny it.
+Yeah. Some good matches.
+Okay. See, it could be a salesman.
+And also these are in a different country again.
+So for preferences, did you put um, a location or?
+Preferences.
+I put sales director work. Put Georgia, United States.
+Okay.
+US only here.
+Oh. Um,
+well, you did say remote though.
+Like.
+Remote in America.
+Why would it matter
+So there has to be like it has to be an option where you can put in remote like location. Because I don’t want a remote working job in Greece.
+Why not Just question. I’m not arguing with you. I’m just curious. Why, why not?
+Um, well, my whole family’s in America. Of course, it’d be a different time zone.
+I um I don’t want to uh,
+you know, be paid in a different currency.
+Um,
+and um you know, it would just be I wouldn’t be able to you know, passport issues and immigration issues. Things like that.
+Mm-hmm. Okay.
+So remote, US. And then remote, worldwide. There should be two location preferences under the work location preferences.
+Yeah.
+So two versions of remote. Remote, US only. A remote you know, remote parentheses, US only. And then remote, worldwide.
+Yeah.
+I mean, if they pay me enough I’ll literally do any remote role anywhere in the world. Like, they’re actually yeah. I mean,
+I mean, I don’t have to travel with them. It doesn’t make their accents are going to be weird anyways because they hire people like everywhere now. Software, so.
+Anyway
+Yeah.
+I mean, shoot. I’ll take a Chinese job if they pay me good.
+Oh, yeah.
+If it’s remote, yeah, why wouldn’t I?
+Although they scare me a little.
+When I find Asian people very intimidating.
+Yeah.
+Yeah. Whenever I have an interview with like an Asian person, I was like, “Fuck, I’m not there’s no way I’m getting this job.” I was like, they’re like, “These people are like, like, yeah, make me very nervous.” Don’t know why.
+There’s so much trick.
+Yeah. I feel like they’re being super strict and judgy. It’s all in my head. It’s probably all in my head. I don’t know. Maybe it’s not. I don’t know. Honestly. But I definitely feel it. Like, I feel being like I’m being like judged, like fucking stupid American.
+So stupid. But I’ve got to deal with these stupid lazy slobs. I don’t know. I’m definitely like prejudiced that way. Thinking that way.
+But that’s I’m just being honest. That’s where I am. That’s how I feel. I had a boss at um, and I worked for Optum. He was Wayne June. And his accent was really hard to understand sometimes. And every time he sent me a message over Teams, it’d be like super nervous. Because first I have to figure out what the hell he was trying to say. Because his English wasn’t great. So even his messages were like kind of cryptic and confusing. I wonder what he means by that. And I couldn’t tell if I was in trouble or if he had an expectation or a deadline or what it was he was asking me. He’s like, “Where is the config file?” I wonder why he’s asking me that. Does he ask me that because we had another conversation that I’ve since forgotten about a config file. And I’m like really dumb about asking him, “What do you mean?” And so I just started asking other people on the teams, “Do you know what he means by this? Do you know what he means by this?” And then I just someone else is like, “Yeah, I think he means this.” It’s like, “Oh, okay.” And then I’ll answer him. Or ask AI is like, “How should I respond to this?” So.
+Wow
+Yeah. Yeah.
+Sounds stressful
+It was I didn’t like him as a boss. It’s too weird.
+But I know
+Yeah. Okay. Cool.
+Moving forward
+So we’re going to add remote, US and remote, worldwide to that option under the where would you like to work.
+Yeah. Okay. Yep. Okay. Moving on.
+Do you like the sentence format or should we just have like short headings with like um,
+back on the preferences page, I mean?
+On the preferences page
+I mean, do you like the questionnaire format where it says where do you value, what do you what kinds of roles? Or do you want to just say.
+Yeah.
+Roles. Role types.
+Um,
+work types. Um, you know what I mean? Do you want to just leave it like sentence format?
+Yeah. I mean, I mean, we did we wanted to work in this so many times. So just keep it here.
+All right I’m making sure. That it’s not stupid just because we’re used to it.
+It’s stupid. Uh, observation.
+Yeah. We’re just just don’t want to get too um, you know, you look at something too long, you lose your perspective. So I try I try not to get too precious with anything, you know? Like, it’s okay to change it. Especially since we have AI to kind of change it.
+It’s true. Yeah. Well, I mean, look, let’s uh, we got to get to the role. Okay. So we’re at the role screen again.
+Okay.
+You gave us some time. We found some new roles.
+All right All right Cinnamon roles.
+After this work after this, we’re going to open a bakery. Call it Role Fairy.
+Have all kinds of roles.
+Well, we’re just going to have a lot of um,
+Batman. Role Fairy. We’re just going to be big fats of going to a boat.
+There you go.
+Oh, so um.
+All right So we couldn’t fix the remote thing yet. Unfortunately.
+Yeah. We couldn’t fix the remote thing. But he wants like an IT.
+I mean, look at his resume. This guy’s resume. He wants like an IT infrastructure IT director kind of role.
+Yeah. Yeah.
+He wants uh, that sort of thing. Like, look at his tenure. Guys can do an infrastructure IT operations.
+Okay. So he’s been a global director and a senior manager and so he’s had like senior management roles. IT firms.
+Yeah. More like yes. IT operations. IT infrastructure. No, he’s he’s looking to work on the infrastructure so there’s no downtime. Everything is working. Everything is, you know, everything is always working. No issues. Servers are up. Just like the, you know,
+that sort of thing.
+All right
+Um,
+managing 18 million budget.
+Applications.
+Um,
+you know,
+directed design installation. So we’re talking like the person that sets up the servers.
+Um,
+buys all that kind of stuff. Uh, you know, he’s he’s he’s purchasing different IT infrastructure. Um, on on-prem, essentially. And then just keeping maintenance of it.
+Yeah.
+So when we go to roles,
+um when you go to match roles,
+it’s not it’s not really showing the right roles there.
+Not doing good for his his uh, genre.
+Jobs.
+Mm-hmm.
+We need to do better for him.
+Well, we’re going to have to do something better for all the people, right?
+Yeah. Yeah. Well, that’s why we have this kind of like that’s why we need to look at different different types of roles, you know, different types of real people. And like, because you’re using a real person, you actually know. You’ve got a much better idea if the app’s working well.
+For people
+Mm-hmm.
+But for this specific use case,
+I don’t think you want I don’t think he wants to be a lead veterinary technician.
+I don’t think he would uh, he would get hired for that.
+Unless he just brings a really cute puppy with him and he’s like, “Hey, look, see this puppy right here? I’m going to save his life.” I know he looks dead, but watch this.
+He gives him CPR. He’s going to give him CPR.
+See, he’s fine.
+Got any more dogs to save
+He had a dog whisper. He has like a dog whisper.
+Mm-hmm.
+All right So you’re all zoomed in now. It might help if you zoomed out. I’m trying to get a picture of what’s going on in the page here. Um,
+so a couple of things I’m noticing. So when it looks at my resume, I get like a lot of strong fit roles. As you pointed out, it could be that there’s a lot of roles for my specific skill set, which is fine. Um, we got it to work better with your resume, right?
+Mm-hmm.
+I think there’s hope. That we can get it to work with his as well.
+Now specifically for IT infrastructure management roles, that’s kind of a a niche I don’t know enough about. But you’re right. We should look and see what what can be expected elsewhere.
+So. Is it Jose? Is that who we’re working with here?
+No, this is Robert.
+Oh, this is a different guy. Okay.
+Oh, I’m just telling you simplify. I just want to simplify.
+Um, I got I forgot to share my entire window.
+Can you uh, can you add Robert and kind of see like what we can expect? I don’t know how much of it is the app and how much of it is his job area. Like, area of expertise. It might just be kind of hard.
+I think he’ll be able to find something.
+Yeah. Well, I’m sure. We’ll figure it out I mean, our app might have to be like better than other people’s app. But I’m just kind of to to base it off of uh, to, you know, to know what we’re comparing it to. So like,
+if it only finds like one job for him here, then okay, we have a bigger challenge. And we’ll still face that challenge. And we’ll we’ll get it to work. But at least it’ll tell us that it isn’t it isn’t as much our app as it is like his niche area of expertise.
+Okay.
+Structure Structure. You are infrastructure.
+IT.
+Infrastructure No, stop right now. You had it? No, the T and then the U.
+Infrastructure. Right? There you go. Another U.
+U U.
+RE man. RE.
+Structure. There you go.
+All right Infrastructure That’s all right. My wife asked me how to spell everything.
+Infrastructure Kill me.
+All right
+Okay. Full-time self-experience.
+I don’t think I don’t work with anything that doesn’t have more than like 5, 10 years experience. I work with no one to level people.
+Yeah. I mean, you should have some experience.
+Otherwise, you don’t really need this app You just need to go talk about your resume or like just walk in and be like.
+Yeah. Like you’re this is what I’m saying. This app is really only for people that have like years of experience and are looking for a really high-quality role.
+It’s either who you know because you have like rich family that will like help you get a job at the country club or something.
+Or or it’s like you don’t have experience and you’re just going to walk in and any fast food will place if you like clean up before you show up there and you don’t have any felonies. Right?
+Yeah.
+Yeah. So yeah. Otherwise, if you have a resume, then you come here. That’s when you apply for a role. Taco Bell isn’t really a role. Right? It’s like.
+Yeah. Taco Bell is more like a fucking.
+Slinging tacos.
+Like a fucking go for a taco right now. We’re doing this thing for Lent where we don’t eat fast food. So I don’t get any tacos. Not for like another 20 days or whatever it is.
+So.
+No Taco Bell for me.
+Yeah.
+That’s what you want.
+What is that Language. This is his last name.
+His last name is Silverado.
+Yeah.
+Words.
+Is that like is that like Scandinavian or where is SV? Where do they put SV?
+SVO. Silverado.
+Is he like a white guy
+He’s a white guy. He’s a white guy. He’s a military guy.
+Yeah.
+He’s a he used to be the he used to be a general general.
+Not general.
+He was a not not general.
+Not general. You just need to retire, man.
+I got to get my rankings right. He’s getting light for me.
+Yeah. After general, you’ve been in for like 20-something years. It’s time to just retire.
+You don’t need a job anymore.
+What’s the I can’t get my major. He’s a major. He’s a major.
+Okay.
+You got out already
+Yeah. He’s out He’s out.
+He definitely has leadership experience.
+Oh, he’s yeah. He’s big into leadership.
+Yeah.
+That’s it I’m a veteran.
+How old is he Roughly.
+Boom.
+He’s like in his 40s or what?
+Yeah.
+It’s like my age.
+Yeah. I don’t really work with a lot of experience, like I said.
+Let’s see if we can put him in healthy.
+There we go.
+Oh, there he is.
+I think I saw him in a commercial.
+No.
+He’s like.
+For like hotels or something.
+He’s moving real fast
+Oh,
+you guys don’t love shit now.
+Yeah, man. He’s doing big things.
+All right Going back to you.
+Now not special. Things like that. Oh, we want to last episode of.
+All right So there.
+Oh, found me 800 jobs already, huh? Maybe I should start looking around.
+802 Yeah. Do you have so many fucking jobs open for your skill set?
+If only I could take I only need one of them.
+Yeah.
+I’m pretty happy where I’m at You’re talking about raising and stuff. And I think they seem to like me.
+I like that I think I think you got a good thing going, man.
+Yeah. I’m going to keep it I mean,
+I got a great relationship with everybody there, which is nice.
+And all the weird accents. All the weird accents went away. With the Jamaicans, they just got rid of all the Jamaicans. So now it’s just me and like three other dudes. Pretty much.
+Wait.
+Yeah. It’s weird. It’s like everybody’s gone.
+Oh, I was saying, these jobs are done, bro. These jobs are just so not a match.
+Mm-hmm.
+Or at least a supervisor. What kind of shit is this?
+For SpaceX a four companies?
+Nice.
+You said aerospace.
+All right So for the transcript, which is pretty all over the place, but for the transcript,
+we have roles, role screen here. We’ve entered a resume for a guy with IT infrastructure senior leadership roles. He was a senior manager and a global director for IT infrastructure roles.
+And his resume reflects that. And his job preferences reflect that. But on the role screen,
+we’re getting jobs that do not relate to that. Like barista supervisor and benefits analyst.
+And executive assistant.
+So yeah, veterinarian.
+Veterinarian.
+Veterinarian.
+Medical director. So none of those roles really even in the smallest way to this guy. I’ll go up to your roles.
+I mean, sorry, your keywords.
+Drop the keyword down and I’ll just stay there and then drop the keywords. There we go. So we have keywords like Splunk, Cisco, Microsoft, Teams.
+Do you want to I mean, you could remove those and see if it does anything. Maybe you’re getting some of that stuff because of the keywords, maybe.
+Yeah. It seems to be veterinarian from Splunk.
+Uh-huh Maybe it’s supposed to be skunk. I don’t know. Just remove them all.
+Yeah.
+I’m a skunk veterinarian, a specialized. I care about skunks. They’re misunderstood.
+Just kind of remove them all. I’m just kind of curious if they have anything to do with what’s happening. Just to kind of just isolate the problem if possible. Yeah. See what happens.
+I don’t know what’s happening.
+Yeah. I don’t know what the research doesn’t automatically.
+I guess so. Yeah.
+Yeah. So we’re not happy with the performance of the role screen for this guy.
+With this IT infrastructure background and very senior management, he was a major in the army.
+But we’re getting roles that don’t seem to relate to any of his experience or preferences, which is unfortunate. So we need to fix that. I don’t know if the role screen is so far we’ve just kind of tailored it to a couple of resumes.
+My resume, which is heavy with AI stuff and your resume, which is recruiting and marketing and stuff. So yeah, we need to make sure it works for this guy. And then we’ll just, I mean, ideally, like you said, it would be nice to work for all kinds of different people, but the only way to test it is one resume at a time. That’s why it’ll be nice to have our beta testers but we’re not quite ready for that because we don’t want them having this experience. That should at least be like close to working. So scroll down and see what’s going on. I think it’s done with whatever it’s going to do. Architectural product designer.
+Senior financial analyst. Benefits partner.
+Oh, it hasn’t changed. Okay.
+There’s no refresh button?
+Scroll back up I think there is a refresh button.
+Yeah. I just took it out. I just took it out.
+Yeah. Maybe I’ll.
+So when you click refresh roles, all of the matched roles should maybe disappear.
+Yeah. Because it’s keeping all the other ones.
+It’s finding matched roles, but I don’t know if it’s removing the ones that are there. It’s just creating a new list and putting it on top.
+Well, go ahead and pick some of these roles. Put them in the preferred list so we can check some other screens because we’ve established there are issues.
+You haven’t added any preferred roles. I know that none of them fit him, but just for the sake of testing other screens and not getting stuck on this one problem.
+Okay. I’m going to do a business intelligence preferred.
+I’m going to be cost Part-time editor.
+AI GTM leader. That’s where associate director.
+Associate store director.
+Business development lead.
+Yeah.
+I’ll put IT technical product.
+Channel resolutions manager.
+Associate store director.
+Or it doesn’t matter. We’re just doing it to test other screens. We’re not. None of these are any good for him anyway, so. They’re all like equally bad.
+So just yeah, just go up there and randomly give them some stars and some ranks so that we can test those things and we can move on to the next screens.
+We’re just trying to make some progress with our app testing. So we can find other bugs to fix, you know?
+Yeah.
+And then I guess rank them however doesn’t matter.
+Okay.
+You didn’t rank any of them. You just gave them stars.
+Oh, I didn’t rank them? Oh, I was giving stars? Okay. I ranked them. Well, I’m going to do the.
+So you can sort them by rank later. Like right now you can sort by number of stars. But if you do it, now you can sort by rank if you give them all a rank.
+Oh.
+Rank is more specific because you can each one only gets its dedicated rank, whereas stars you can have a whole bunch that are five stars and then there’s no particular order to them.
+Like if it were me and I had my 800 roles in there or whatever, I’d be like, you know, I’d only, I might have a whole bunch that are five star, but I’d only have one that’s number one, you know?
+But I may not really like how I ranked them because it’s too much work. So I might stick with the preferences and just do all the five-star ones because I don’t care. They’re all good, you know?
+All right
+I’m going to sort sorting methods as well. So you don’t spend all your time looking at the wrong ones.
+I like that it’s giving you salaries for those. That’s good. Something’s working.
+Yeah. That’s a good thing.
+Okay. So go ahead and run the gap analysis. See if that’s working.
+We’re going to find issues. It’s okay.
+That’s what we’re doing. Fixing them.
+Is that what goes? Even with my job, we find all kinds of stuff. So we’ve got two jobs with major gaps, one job with minor gaps, and one job with my moderate gaps.
+One with minor gaps is the business intelligence and insights analyst.
+We go ahead and see what those are if you want.
+It’s got zero resume gaps. About that.
+So that’s weird because so yeah, we’re on the gap screen, Mr. Transcript. And we are seeing zero resume gaps for a job that definitely has gaps. We’re looking at a business intelligence and insights analyst marketing analytics role for Elastic. And the resume on file is IT infrastructure senior manager. But there’s no way that resume matches the job. So the resume gaps isn’t doing a very good job. It’s not showing. It’s not populating well for the gaps. So that needs to be checked. And fixed.
+For the personality gaps, it’s probably fine. For the preference gaps, location preference mismatch you selected Georgia. But this job appears to be in the United States.
+I mean, okay, I think most people who use this app will be in the United States. At least for now. I don’t think we’re going to get a whole bunch of people from Georgia, the country. So I wouldn’t assume that Georgia is although Georgia, the country, like does the job just check it real quick. I’m curious if that’s a bug or if it’s actually accurate.
+No, no. I’m going to pick it. It can’t be.
+Go back. You don’t know. There’s jobs in other countries on our list. Databricks, where are they located? United States. What’s the next one? Associate director.
+United States. What’s the customer of the solutions manager?
+Yeah, I don’t know
+Newark California.
+Huh Okay, whatever. There’s no Georgia job. What’s it even talking about?
+I put in I wanted to be in Georgia, Atlanta. Atlanta, Georgia, not the country of Georgia.
+And they’re like, well, it looks like a mismatch because you selected Georgia.
+Well, I would go back to. The preferences and get rid of that. Are you going to keep running into it?
+So well, it’s also a country.
+There’s a country called Georgia.
+It says it’s a state. Have you assumed it is a United States? What state?
+Oh, that’s an app glitch. So if they select the US, the US state, Georgia, it shouldn’t be saying like it shouldn’t be saying that you selected Georgia, but this job is in the United States. And then filter out all those jobs. I wonder if that has something to do with it. Can you get rid of the Georgia thing for now just to test it?
+Maybe that’s getting in the way of his roles.
+Maybe he’s looking for jobs like in Georgia, the country.
+I didn’t put US only
+Yeah, yeah. Well, it’s not perfect yet. We’re still working on it. It’s like do that. We’re testing things. I’m not trying to prove that it works. I’m trying to figure out where it doesn’t. So get rid of the thing. Then select the state. Just pick a different state. Just for the fuck of it.
+Where is he Is he actually in Georgia?
+I don’t know
+Is he in Georgia, the state?
+Yeah, he’s in the state. He’s in Atlanta, Georgia again.
+It’s Atlanta.
+I noticed a lot of job apps will put the main city like the nearest city. I wanted to say what state. It’ll say like Atlanta, Georgia. It’ll say like Portland, Oregon. And it’ll be like San Francisco, California, Los Angeles, California. And have like a few cities in California. Like because they’re like not just the state, right?
+You can’t just put the state. Yeah, you got to have cities.
+The nearest city So instead of United States, what state on the preferences page we should put city-state combos, nearest instead of saying United States.
+Oh, like yeah, like the nearest metropolitan city kind of thing.
+There you go. That’s maybe just say that. Nearest metropolitan city. And then yeah, or nearest city.
+Because that’s what they’re always doing. You know, it’s Denver, Colorado.
+Charleston, South Carolina. It’s Dallas, Texas.
+Yeah, there’s a big difference between like Dallas and Austin, Texas. They’re not close to each other. And you know, Sacramento, I mean, not Sacramento, but San Antonio, Texas, is pretty far. Well, it’s maybe two and a half to three hours from Austin. But then Dallas is like five hours from there, right? Lubbock is like super far. So like, yeah, it matters. So yeah, instead of state, it should be like nearest city. That would make more sense. It actually, like if you were in Vancouver, Washington, you could drive to Portland in half an hour. Portland, Oregon.
+Yeah, but still, it’s got to be the biggest city or the most well-known city or like the metropolitan city. Like if I told you South Carolina and then I said, you know, Bakersfield, South Carolina, or what the fuck that is, you know, you know, Charleston, South Carolina, it’s like a major city. People recognizable.
+No, what I’m trying to say is it should be multiple big cities within each state.
+Oh, multiple big cities in each state.
+Well, yeah, because Austin, Texas, and Dallas, Texas are two completely different regions.
+San Francisco, California, and Los Angeles, California are like five hours from each other. Right?
+But Vancouver, Washington, and Portland, Oregon are 30 minutes away from each other. And they’re two different states. So the state isn’t that helpful. What helps is knowing the major city that it’s next to. So you don’t want I wouldn’t look for if I was willing to travel, which I don’t really see the point, because there’s enough remote jobs. But if I was willing to go, I definitely wouldn’t be willing to move to Dallas.
+I would be willing to go to Austin.
+Right So I don’t want it to list 100 jobs for Dallas because there’s plenty of jobs and they pay well. But I’m not going to Dallas.
+It’s super far. And like, it’s two Republican. You know? I wouldn’t go there. Austin is Austin’s like way liberal. The cost of living just got super high because all the LA people moved there. But it’s like, you know, it’s always been super liberal city for Texas. Austin does. So I mean, I would just much rather move to Austin. I would be if I found a good enough job there, I’d be like, sure, I’ll go. Right? Because that’s a place we wouldn’t want to be.
+Well,
+what I know about you all is you like the arts, too. You like art, you know, art and creative people. And those kinds of people. That’s all like that’s all Austin, right?
+Yeah, yeah, the big city We go to ACL like pretty often. Like we’ve been like four times with our kids.
+Austin City Limits is like a big concert festival and all the musicians come.
+Yeah, I want to go there. I’ve never been to that. You know.
+Yeah, it’s fun It was cheaper when the kids were young enough to get in free, but now they have to pay for all of them, so. It’s okay.
+Yeah, I’m getting pretty tired. I got to go.
+Okay, so anyways, we need to fix the preferences screen so that instead of United States, what state it needs to say nearest metropolitan area. And it needs to have all the metropolitan areas some states will have two or three some states will have one or two.
+But yeah, there needs to be at least one major metropolitan area per state. And for California, you should have like probably three minimum, right? And then Texas will need probably three at least San Antonio, Austin, and Dallas. Those are like the three major ones, but maybe Lubbock, too. Even though Lubbock’s not that big, it’s pretty far from the others. There’s also like El Paso, which is another one. In Texas. So it needs like plenty of metropolitan areas.
+And then then when it won’t be like, oh, you said Georgia. You’re in another country. It won’t be stupid.
+But let’s go back to so you put it in Idaho. I want you to do a quick test before it sounds like you’re getting tired and I’m I’ve been too zoned into my work to like think straight. And then the kids are telling me it’s time for dinner. So go to roles or go ahead and save and continue first.
+Yeah.
+And then it’s saving. So hopefully then click roles.
+And I guess like refresh the key frame over here. Huh?
+Checking out over here with the keywords and then.
+It’s already refreshing, I guess.
+So the keyword it’s always refreshing in this area. Like constantly refreshing.
+Well, it refreshes when you load the screen. Or when you update the keywords.
+Yeah.
+It’s a little annoying. Only because it shouldn’t refresh just because you clicked on one of the keywords.
+I get it when you load the screen. No reason for it to wait, but you might be wanting to select more. Oh, it’s getting better. Look at that. Director of Global Communications and Social Media is not perfect. Account Manager is still kind of like sales. Director of Content Management.
+Yeah.
+Still shitty. It’s funny it’s giving you Georgia.
+Boss Manager. Commercial Account Manager. Technical Accounting.
+IT Infrastructure What are these guys doing?
+So far it’s got zero.
+It takes time.
+All right
+15 We got 15.
+Oh, okay. You got 15 Let’s see what they look like. Let’s see if they’re actually what we think they are or if they’re just blowing smoke and it’s a bunch of nonsense.
+Okay. Senior Director EDP, Operations, Cloud Identity and Access Management.
+This is not bad.
+Information Security. That one’s actually a really good fit. That third one in Sweeney, Georgia.
+Enterprise Sales Director,
+that one’s a really good fit. The other ones are maybe I don’t know what an EDP Operations.
+No, this one’s good. IT Infrastructure. This is exactly what I know.
+Okay.
+So I should maybe tell the transcript here that when we went on Simple AI dot AI and looked for these senior management IT infrastructure roles, it did find some. It found one for TTM Technologies.
+A remote job. It’s a senior project manager and IT infrastructure, which is a really good fit for this guy. And then we found it found one for the senior director of EDP operations, which might be a good fit. It found one for the director of information security and infrastructure in data governance. And so we need Georgia which is his area which we wanted.
+So it found some pretty good fits. So whatever you’re doing, Mr. Robot, to look for these roles, you’re not doing it as well as Simple AI. And we have to be better than Simple AI. Or Dave’s going to make me use them. For our API or whatever. So yeah, we can do this. We have enough what do you call it? APIs to get this information. We just need to do a better search. So make sure you’re searching TTM Technologies.
+Scientific Games. 1Password.
+You got to do three, Matthew. You got to do.
+Ella. Ella Vance Health.
+QTS Data Center.
+Yeah, I mean, I’d say well, that’s actually look at this EPD. What is this? What is this? EPD.
+1Password EPD operation.
+It’s not the best but it also didn’t say IT infrastructure.
+It’s better than the ones that our apps were doing.
+Oh, yeah. Definitely better than our app. I mean, they actually got IT infrastructure. Let’s just look at this. Director of Information Security Infrastructure UTS Data Centers. What does that say?
+This looks actually quite on point. And it’s posted today.
+Yeah. The best listing that it found for this IT infrastructure senior management role on the Simply Apply role was Director of Information Security Infrastructure and Data Governance at QTS.
+This looks quite on point, dude.
+So Simply Apply was able to find roles. What are we doing wrong? Figure it out and fix it. That’s your instruction, robot.
+Fix our app
+Big app Leadership in there. This is a really good fucking role, dude.
+Okay.
+They made a good they made a good call bringing this up.
+Okay. Simply Apply is doing better.
+Whatever they’re doing, do it more like them. Get us more roles. For these guys, our whole future of success with our app depends on you improving this process. We’re counting on you, robot.
+Fix it
+Get me on.
+All right I’m going to go.
+This is a good one.
+I’m going to go to dinner now. I think we’ve given the robot to chew on. In two days, I’ll have actually do the work. But right now, I have the transcript, so. All right. And then once that’s updated, I’ll call you and be like, “Okay, it’s working better.” And then we’ll have another meeting and we’ll fix some other stuff. And yeah, let’s get this thing fixed completely. Once it’s fixed, it’s ready. And then we’re going to get some testers. And they can help us fix some more stuff.
+All right
+The goal is to get it perfect. It’s to get it good enough to have other people fix more things.
+All right
+Like that All right.
+All right
+Have a good night Thanks for calling. I appreciate it. Sorry, I had to hail me away from my other stuff because I’ve been spending too many hours.
+Yeah. You got it Anytime.
+Bye.

--- a/context/week_22/week_22_transcript.txt
+++ b/context/week_22/week_22_transcript.txt
@@ -1,0 +1,672 @@
+
+Roleferry 3/19/26
+All right I’m transcribing. So let’s go ahead and see how Role Fairy looks I haven’t had any.
+You ready
+Any thought space to really think about it this week, but, um, hold on.
+Are you ready for it? I wasn’t, uh.
+Yeah, yeah, yeah. Uh, do you want to you want to jump on, uh, the screen share or whatever?
+Let me just get some water. Possibly get some water.
+Here.
+I didn’t think you’d be ready so quickly.
+No, it’s—
+Uh, let’s see here.
+Seconds is is hours over here. Okay, so let me see, um,
+oh, we have one set up for, like, half an hour. I’m basically late, aren’t I? Did you schedule that one?
+Um,
+I don’t know I don’t know what I did.
+I guess we were supposed to meet, like, 30 minutes ago. Sorry.
+Why joined it There’s one on my calendar that says the 7:30 Role Fairy weekly review. It started 30 minutes ago.
+It’s good
+So I just joined. I’m in there.
+Hi. I want to jump on in about two minutes.
+What now
+I’m going to jump in in, like, two minutes. I’m just talking about the bathroom real quick.
+Yeah, go for it All right See you there. Bye.
+Okay.
+All right I’m going to go ahead and walk through the Role Fairy screens.
+So I am on the login screen of Role Fairy, and I am using my username, and my login to get in. I have now logged into Role Fairy. I see the role preferences screen. Everything is collapsed as desired. That looks good. My minimum expected salary is $200,000 in there.
+I have things checked. That looks fine. I’m probably fine with aerospace, so I’m going to add that as one of my industries.
+It says, “What industries are you exciting for you?” Um,
+I’ll go ahead and click all sizes of companies so that I can see the job roles that might come up when I do that.
+Let’s see.
+Okay.
+Yeah. All right
+All right.
+All right. So are you still there?
+Sorry Closed the wrong window.
+All right Still there?
+You’re welcome.
+Yeah, you’re back Sorry about that. Yeah, so, uh, I was, uh, just looking at the screen here.
+Um.
+Mm-hmm.
+All right
+Yeah.
+So I logged in I’m on the first screen. Making sure these things are correct.
+Oh, I’m trying to get everything. I’m not there yet, swear.
+Windows open here.
+Okay.
+I don’t know You delete, delete.
+Is that down? Is this down?
+Um, is this down?
+Okay.
+All right Um, okay. And then we’re going to yeah, looking for my window.
+Uh, okay. Zoom out.
+Okay. I’m in. I’m in.
+All righty.
+Okay. How about you share? That way,
+um I was am I sharing? I’m not sharing, of course.
+No, you’re sharing.
+Okay.
+Um, okay.
+All right.
+Okay.
+All right Um,
+so I think that we’ve gotten really far here, but, um,
+let’s see. Maybe I’ll go to, um,
+do one start from the beginning?
+Yeah, go ahead. Start from the beginning. Talk it through.
+Yeah.
+Okay.
+All right
+Processing it.
+The guy at work’s asking me questions. Oh, we got problems?
+HTTP 500 Let me see what happened.
+No, try look at the dev tools.
+I mean, like, you know, left, right click, and
+I was going to give you another file.
+Yeah, just try, try to right click it.
+And then.
+New page source
+Yeah, view the source and see what errors there are.
+Oh, inspect, inspect. Okay.
+Are there errors Click on the console, not elements. Console, where the red X wasn’t there. Over on the here we go, right there. Console.
+Oh, console.
+There you go.
+You just copy and paste all that into the chat for me.
+Hmm.
+Um,
+actually,
+okay.
+I’ve been using Claude to, um,
+kind of replace Claude.
+Oh, yeah.
+Yeah.
+Claude is getting crazy.
+So I just um put another resume in. It worked better.
+My resume I put in there. Got a little funky.
+Sorry, Nana. I’m super, like, getting messages from this guy at work. Um,
+so I’m just kind of trying to finish dealing with him. All right. Um,
+I mean, I just have to do it So let’s see. Um,
+where is shouldn’t be working at 8:00 at night, man.
+Yeah, I can’t be working. I don’t think you’re going to be working at night. That’s why I called you.
+Okay.
+No, I’ll be done with him in a sec. I just need to just need to deal with him.
+One second here.
+Okay.
+I’m going to send this guy a document and then I’ll give him my full attention.
+Um, tell him to leave me on for a while because I’ll be, like, gone. Okay. Um,
+okay. I’m going to show him my status as offline so this guy stops messaging me because it’s impossible to multitask right now.
+Appear offline.
+Yeah.
+Now I am invisible, and he cannot talk to me. All right. And I’m going to close Teams, so that’ll help too. Okay.
+Sorry about that Um, back to Role Fairy. Okay. So did you get past the error you were having?
+Um, yeah. I put it in a different resume, and it seemed to work out.
+Oh, okay. Okay. Well, then if you don’t have it with a I don’t know what happened. Maybe it was just a glitch.
+We don’t want our clients to
+Yeah. It seems to work with some resume.
+So this, uh, so I was testing out the different resumes.
+Okay.
+Um, but yeah, I’m using, uh, Role Fairy now.
+Okay.
+Um,
+roles. So the roles?
+All right How’s that working?
+I think the I think the roles, uh, I didn’t update the keywords, the different resume.
+It might automatically refresh. Just it might be a little delayed.
+Remember it might remember it did last time.
+So.
+Yeah. That’s the real I really want to test that in different resumes.
+Oh, yeah. One thing we talked about was, like, creating other accounts. Like,
+like a different resume, and because you know what? It’s going to kind of.
+You know what I’m going to do that I’m actually going to do that I’m going to create a new account.
+It’s like caching old stuff. That way, you don’t have to worry about it. But you can just create maybe use it based on one of the resumes you have.
+This little estimated name. Like, do you have a resume that’s, like, for a client you can create a fake thing for him?
+Yeah, yeah, yeah, yeah. I’m just going to make up an email address.
+Well, I think you’re going to need an email address because it sends you a confirmation, doesn’t it?
+Yeah. I’m not making up, but you know, using other ones.
+Okay.
+Is John Jacobson a client You have the resume?
+No, it’s just a fake name that I’ve used.
+Okay. Do you have a resume that says John Jacobson, though?
+No. So I use a name that actually matched in the resume.
+Yeah. That’s what I was thinking because that way, it’s not going to be confusing later if it’s working. I don’t want there to be confusion about whether the app’s working. If you, uh.
+Okay. I’ll use another card. Robert. What’s his last name? Let me just try to spell his last name.
+All right Let’s see here. Um,
+let’s change.
+Let’s see.
+Um, whatever resume you find and make the account for that guy. Email doesn’t matter, but, uh, yeah.
+Yeah. The way weird names show up, you’re not thinking it’s the app’s fault or vice versa.
+Yeah, yeah.
+Or if it is the app’s fault, you’ll know it.
+Um,
+my email address My phone number Yeah. Password.
+Email. Password.
+I see some match. It has all right. Wait. It’s in I’m in the same. I literally put Robert in, and now I have David again.
+All right You’re logged into that’s weird. So just for the transcript, so you logged into a different account, and it still says, “Hi, David.”
+So it’s going off of your IP address or something. Instead of your login.
+Or maybe some information on your computer, maybe.
+No, it’s crazy.
+Yeah. Maybe you didn’t log did you log in or did you, like,
+go
+I was logged out because that was crazy.
+Yeah. She said Robert
+Yeah.
+Let’s see if I got a confirmation email Tuesday that the email address.
+Hmm.
+I didn’t get a confirmation email to the email address.
+Well, that’s not good Let’s test other screens. I’ll go over that as fixed.
+Like I said, it might be able to fix anything real-time for like two days, so.
+Okay. So yeah. We just want to know that the, uh, when you log in under new account, it’s still having my old account in there.
+Yeah.
+Yeah. David.
+And it’s not created a new, uh, user account for a different person. Put a different name, and it’s still saying, “Hi, David,” at the top right, so.
+Hi, David. And it has all my old information.
+And it’s saved it’s somehow all his cached could be your browser.
+It’s got to be your browser. Caching. Can you, like, use a different browser?
+I can use a different browser.
+I just got yeah, it’s got all your, uh, cached stuff. If you log into a different account, it shouldn’t have cached stuff in there.
+I’m using Google Chrome instead of uh, Microsoft, uh, Explorer.
+All right Log out.
+First name is my main one.
+I’m going to make it different
+Can you clear the cache up there in your settings too?
+Okay. Settings.
+Yeah.
+Um,
+that wasn’t there.
+Yeah. Like, clear the cache.
+Settings.
+System You see my screen, right?
+Yeah, I do now I couldn’t see the dropdown from before. Go to, like.
+I’m on settings over here. What am I supposed to go?
+I’m going to go to privacy and security.
+Okay.
+And then, um, delete browsing data, history, cookies, cache, and more.
+Okay.
+And then just delete data.
+Okay.
+There you go.
+There you go. You should be good now
+All right So now.
+Close that
+I am
+Close your tab.
+Okay. Now I’m back on the screen.
+You’re there. Now log in To the one you just.
+I’m logging into the new account. Should say Robert.
+Yeah. So
+one thing we should fix, though, is we don’t want catch cached, um,
+screens to show up for you if you log into a different account. So that’s a it’s still a bug that needs to be fixed.
+But for now it’ll it shouldn’t be happening anymore. If it is, then there’s another problem. I don’t think it is.
+But it is. So there’s another problem.
+Let’s just log in.
+Okay. That’s weird.
+Should say Robert
+Yeah.
+You did you did put Robert in there, right?
+Yeah. Robert’s the name of the account.
+Well, it’s just a bug. It needs to be fixed. Let’s not spend any more time on it because it’s just a bug. I’ll fix it.
+Okay.
+I mean, it’s it’s a big deal, but it’s not a big-time thing. It’s like we can move on. I’ll fix it. It’s good that we noted it. Now I can fix it.
+Okay. All right
+Mm-hmm.
+Sorry that that is there. But it is what it is.
+There’s another good reason we’re testing that, right? Like, we we just discovered another bug by by doing that.
+There’s some, like, really weird IP caching happening that I don’t understand, but. But yeah. I’ll fix it.
+Okay. Robert Okay.
+Looks good.
+Um, next.
+I’m going to go through this whole personnel thing.
+Just click something. Click them all just so you’ve had it there. They don’t have to be accurate.
+Just click them all
+Yeah. I mean, as long as it matches to whatever the type is.
+Doesn’t really matter since we’re not actually trying to find him a job through here yet necessarily. Although he probably wouldn’t mind, but.
+It’s going to say type psychopath. Job recommended cannibal.
+You’re not doing that I think you got to put you have to do the four temperaments one first.
+Oh, okay.
+Unless I didn’t, uh,
+uh, no, I didn’t put them up on it. Um, press this button.
+Oh.
+The dropdown
+But okay.
+Okay.
+So we got to continue.
+Now we can role search The thing is role search. Now it should not have any of my um,
+information. Okay. It doesn’t. Okay. Good.
+Okay.
+Something.
+Splunk
+I don’t know. Yeah.
+Um, let’s see. I’m not sure. Executive. Chief economist. This is the.
+Why is it not in match It says preferences. Maybe I got to redo this.
+What’s up Yeah.
+Technical engineering. Missionary engineering.
+Um,
+that’s not perfect. Managing.
+Is my brain working? Technical engineering. Yes.
+Patient training. Pharmaceutical industry.
+Those are the two kind of ones we’d be interested in.
+Platform It has to be um, so you could do remote hard or person. And let’s see.
+No, categories we’re looking for.
+What’s on?
+Okay.
+Yeah. The longer you’re unemployed, if you like need a job, it just drops and drops and drops. You’re like, “Oh, I’ll take whatever I can.” So.
+Yeah. Just another guy was doing it the other day. It was like, uh, he’s like, “We’re trying to get out of like auto dealerships. Car dealerships.
+Um,
+and he’s looking, looking, looking and eventually just took another job at the car dealership.”
+Yeah.
+Well, that’s where you’re for they’re going to look at your experience. They’re going to want to know what you’re going to do stuff.
+Okay. So jobs that okay. So um,
+we got keywords. We’re trying to get the matches. And then what we did what I did just before was I updated the preferences section.
+Oh, okay.
+Because he doesn’t want any roles within sales.
+It’s roles within tech.
+So you’re going to you’re going to put something in negative keywords for sales?
+Well, we’re getting a lot of sales roles. So like account executive. We’re getting a lot of sales roles.
+Account executive. So down under negative keywords, put sales.
+There you go.
+I think there’s some kind of new yeah.
+Dude, I know guys’ system was good, man. You can’t deny it.
+Yeah. Some good matches.
+Okay. See, it could be a salesman.
+And also these are in a different country again.
+So for preferences, did you put um, a location or?
+Preferences.
+I put sales director work. Put Georgia, United States.
+Okay.
+US only here.
+Oh. Um,
+well, you did say remote though.
+Like.
+Remote in America.
+Why would it matter
+So there has to be like it has to be an option where you can put in remote like location. Because I don’t want a remote working job in Greece.
+Why not Just question. I’m not arguing with you. I’m just curious. Why, why not?
+Um, well, my whole family’s in America. Of course, it’d be a different time zone.
+I um I don’t want to uh,
+you know, be paid in a different currency.
+Um,
+and um you know, it would just be I wouldn’t be able to you know, passport issues and immigration issues. Things like that.
+Mm-hmm. Okay.
+So remote, US. And then remote, worldwide. There should be two location preferences under the work location preferences.
+Yeah.
+So two versions of remote. Remote, US only. A remote you know, remote parentheses, US only. And then remote, worldwide.
+Yeah.
+I mean, if they pay me enough I’ll literally do any remote role anywhere in the world. Like, they’re actually yeah. I mean,
+I mean, I don’t have to travel with them. It doesn’t make their accents are going to be weird anyways because they hire people like everywhere now. Software, so.
+Anyway
+Yeah.
+I mean, shoot. I’ll take a Chinese job if they pay me good.
+Oh, yeah.
+If it’s remote, yeah, why wouldn’t I?
+Although they scare me a little.
+When I find Asian people very intimidating.
+Yeah.
+Yeah. Whenever I have an interview with like an Asian person, I was like, “Fuck, I’m not there’s no way I’m getting this job.” I was like, they’re like, “These people are like, like, yeah, make me very nervous.” Don’t know why.
+There’s so much trick.
+Yeah. I feel like they’re being super strict and judgy. It’s all in my head. It’s probably all in my head. I don’t know. Maybe it’s not. I don’t know. Honestly. But I definitely feel it. Like, I feel being like I’m being like judged, like fucking stupid American.
+So stupid. But I’ve got to deal with these stupid lazy slobs. I don’t know. I’m definitely like prejudiced that way. Thinking that way.
+But that’s I’m just being honest. That’s where I am. That’s how I feel. I had a boss at um, and I worked for Optum. He was Wayne June. And his accent was really hard to understand sometimes. And every time he sent me a message over Teams, it’d be like super nervous. Because first I have to figure out what the hell he was trying to say. Because his English wasn’t great. So even his messages were like kind of cryptic and confusing. I wonder what he means by that. And I couldn’t tell if I was in trouble or if he had an expectation or a deadline or what it was he was asking me. He’s like, “Where is the config file?” I wonder why he’s asking me that. Does he ask me that because we had another conversation that I’ve since forgotten about a config file. And I’m like really dumb about asking him, “What do you mean?” And so I just started asking other people on the teams, “Do you know what he means by this? Do you know what he means by this?” And then I just someone else is like, “Yeah, I think he means this.” It’s like, “Oh, okay.” And then I’ll answer him. Or ask AI is like, “How should I respond to this?” So.
+Wow
+Yeah. Yeah.
+Sounds stressful
+It was I didn’t like him as a boss. It’s too weird.
+But I know
+Yeah. Okay. Cool.
+Moving forward
+So we’re going to add remote, US and remote, worldwide to that option under the where would you like to work.
+Yeah. Okay. Yep. Okay. Moving on.
+Do you like the sentence format or should we just have like short headings with like um,
+back on the preferences page, I mean?
+On the preferences page
+I mean, do you like the questionnaire format where it says where do you value, what do you what kinds of roles? Or do you want to just say.
+Yeah.
+Roles. Role types.
+Um,
+work types. Um, you know what I mean? Do you want to just leave it like sentence format?
+Yeah. I mean, I mean, we did we wanted to work in this so many times. So just keep it here.
+All right I’m making sure. That it’s not stupid just because we’re used to it.
+It’s stupid. Uh, observation.
+Yeah. We’re just just don’t want to get too um, you know, you look at something too long, you lose your perspective. So I try I try not to get too precious with anything, you know? Like, it’s okay to change it. Especially since we have AI to kind of change it.
+It’s true. Yeah. Well, I mean, look, let’s uh, we got to get to the role. Okay. So we’re at the role screen again.
+Okay.
+You gave us some time. We found some new roles.
+All right All right Cinnamon roles.
+After this work after this, we’re going to open a bakery. Call it Role Fairy.
+Have all kinds of roles.
+Well, we’re just going to have a lot of um,
+Batman. Role Fairy. We’re just going to be big fats of going to a boat.
+There you go.
+Oh, so um.
+All right So we couldn’t fix the remote thing yet. Unfortunately.
+Yeah. We couldn’t fix the remote thing. But he wants like an IT.
+I mean, look at his resume. This guy’s resume. He wants like an IT infrastructure IT director kind of role.
+Yeah. Yeah.
+He wants uh, that sort of thing. Like, look at his tenure. Guys can do an infrastructure IT operations.
+Okay. So he’s been a global director and a senior manager and so he’s had like senior management roles. IT firms.
+Yeah. More like yes. IT operations. IT infrastructure. No, he’s he’s looking to work on the infrastructure so there’s no downtime. Everything is working. Everything is, you know, everything is always working. No issues. Servers are up. Just like the, you know,
+that sort of thing.
+All right
+Um,
+managing 18 million budget.
+Applications.
+Um,
+you know,
+directed design installation. So we’re talking like the person that sets up the servers.
+Um,
+buys all that kind of stuff. Uh, you know, he’s he’s he’s purchasing different IT infrastructure. Um, on on-prem, essentially. And then just keeping maintenance of it.
+Yeah.
+So when we go to roles,
+um when you go to match roles,
+it’s not it’s not really showing the right roles there.
+Not doing good for his his uh, genre.
+Jobs.
+Mm-hmm.
+We need to do better for him.
+Well, we’re going to have to do something better for all the people, right?
+Yeah. Yeah. Well, that’s why we have this kind of like that’s why we need to look at different different types of roles, you know, different types of real people. And like, because you’re using a real person, you actually know. You’ve got a much better idea if the app’s working well.
+For people
+Mm-hmm.
+But for this specific use case,
+I don’t think you want I don’t think he wants to be a lead veterinary technician.
+I don’t think he would uh, he would get hired for that.
+Unless he just brings a really cute puppy with him and he’s like, “Hey, look, see this puppy right here? I’m going to save his life.” I know he looks dead, but watch this.
+He gives him CPR. He’s going to give him CPR.
+See, he’s fine.
+Got any more dogs to save
+He had a dog whisper. He has like a dog whisper.
+Mm-hmm.
+All right So you’re all zoomed in now. It might help if you zoomed out. I’m trying to get a picture of what’s going on in the page here. Um,
+so a couple of things I’m noticing. So when it looks at my resume, I get like a lot of strong fit roles. As you pointed out, it could be that there’s a lot of roles for my specific skill set, which is fine. Um, we got it to work better with your resume, right?
+Mm-hmm.
+I think there’s hope. That we can get it to work with his as well.
+Now specifically for IT infrastructure management roles, that’s kind of a a niche I don’t know enough about. But you’re right. We should look and see what what can be expected elsewhere.
+So. Is it Jose? Is that who we’re working with here?
+No, this is Robert.
+Oh, this is a different guy. Okay.
+Oh, I’m just telling you simplify. I just want to simplify.
+Um, I got I forgot to share my entire window.
+Can you uh, can you add Robert and kind of see like what we can expect? I don’t know how much of it is the app and how much of it is his job area. Like, area of expertise. It might just be kind of hard.
+I think he’ll be able to find something.
+Yeah. Well, I’m sure. We’ll figure it out I mean, our app might have to be like better than other people’s app. But I’m just kind of to to base it off of uh, to, you know, to know what we’re comparing it to. So like,
+if it only finds like one job for him here, then okay, we have a bigger challenge. And we’ll still face that challenge. And we’ll we’ll get it to work. But at least it’ll tell us that it isn’t it isn’t as much our app as it is like his niche area of expertise.
+Okay.
+Structure Structure. You are infrastructure.
+IT.
+Infrastructure No, stop right now. You had it? No, the T and then the U.
+Infrastructure. Right? There you go. Another U.
+U U.
+RE man. RE.
+Structure. There you go.
+All right Infrastructure That’s all right. My wife asked me how to spell everything.
+Infrastructure Kill me.
+All right
+Okay. Full-time self-experience.
+I don’t think I don’t work with anything that doesn’t have more than like 5, 10 years experience. I work with no one to level people.
+Yeah. I mean, you should have some experience.
+Otherwise, you don’t really need this app You just need to go talk about your resume or like just walk in and be like.
+Yeah. Like you’re this is what I’m saying. This app is really only for people that have like years of experience and are looking for a really high-quality role.
+It’s either who you know because you have like rich family that will like help you get a job at the country club or something.
+Or or it’s like you don’t have experience and you’re just going to walk in and any fast food will place if you like clean up before you show up there and you don’t have any felonies. Right?
+Yeah.
+Yeah. So yeah. Otherwise, if you have a resume, then you come here. That’s when you apply for a role. Taco Bell isn’t really a role. Right? It’s like.
+Yeah. Taco Bell is more like a fucking.
+Slinging tacos.
+Like a fucking go for a taco right now. We’re doing this thing for Lent where we don’t eat fast food. So I don’t get any tacos. Not for like another 20 days or whatever it is.
+So.
+No Taco Bell for me.
+Yeah.
+That’s what you want.
+What is that Language. This is his last name.
+His last name is Silverado.
+Yeah.
+Words.
+Is that like is that like Scandinavian or where is SV? Where do they put SV?
+SVO. Silverado.
+Is he like a white guy
+He’s a white guy. He’s a white guy. He’s a military guy.
+Yeah.
+He’s a he used to be the he used to be a general general.
+Not general.
+He was a not not general.
+Not general. You just need to retire, man.
+I got to get my rankings right. He’s getting light for me.
+Yeah. After general, you’ve been in for like 20-something years. It’s time to just retire.
+You don’t need a job anymore.
+What’s the I can’t get my major. He’s a major. He’s a major.
+Okay.
+You got out already
+Yeah. He’s out He’s out.
+He definitely has leadership experience.
+Oh, he’s yeah. He’s big into leadership.
+Yeah.
+That’s it I’m a veteran.
+How old is he Roughly.
+Boom.
+He’s like in his 40s or what?
+Yeah.
+It’s like my age.
+Yeah. I don’t really work with a lot of experience, like I said.
+Let’s see if we can put him in healthy.
+There we go.
+Oh, there he is.
+I think I saw him in a commercial.
+No.
+He’s like.
+For like hotels or something.
+He’s moving real fast
+Oh,
+you guys don’t love shit now.
+Yeah, man. He’s doing big things.
+All right Going back to you.
+Now not special. Things like that. Oh, we want to last episode of.
+All right So there.
+Oh, found me 800 jobs already, huh? Maybe I should start looking around.
+802 Yeah. Do you have so many fucking jobs open for your skill set?
+If only I could take I only need one of them.
+Yeah.
+I’m pretty happy where I’m at You’re talking about raising and stuff. And I think they seem to like me.
+I like that I think I think you got a good thing going, man.
+Yeah. I’m going to keep it I mean,
+I got a great relationship with everybody there, which is nice.
+And all the weird accents. All the weird accents went away. With the Jamaicans, they just got rid of all the Jamaicans. So now it’s just me and like three other dudes. Pretty much.
+Wait.
+Yeah. It’s weird. It’s like everybody’s gone.
+Oh, I was saying, these jobs are done, bro. These jobs are just so not a match.
+Mm-hmm.
+Or at least a supervisor. What kind of shit is this?
+For SpaceX a four companies?
+Nice.
+You said aerospace.
+All right So for the transcript, which is pretty all over the place, but for the transcript,
+we have roles, role screen here. We’ve entered a resume for a guy with IT infrastructure senior leadership roles. He was a senior manager and a global director for IT infrastructure roles.
+And his resume reflects that. And his job preferences reflect that. But on the role screen,
+we’re getting jobs that do not relate to that. Like barista supervisor and benefits analyst.
+And executive assistant.
+So yeah, veterinarian.
+Veterinarian.
+Veterinarian.
+Medical director. So none of those roles really even in the smallest way to this guy. I’ll go up to your roles.
+I mean, sorry, your keywords.
+Drop the keyword down and I’ll just stay there and then drop the keywords. There we go. So we have keywords like Splunk, Cisco, Microsoft, Teams.
+Do you want to I mean, you could remove those and see if it does anything. Maybe you’re getting some of that stuff because of the keywords, maybe.
+Yeah. It seems to be veterinarian from Splunk.
+Uh-huh Maybe it’s supposed to be skunk. I don’t know. Just remove them all.
+Yeah.
+I’m a skunk veterinarian, a specialized. I care about skunks. They’re misunderstood.
+Just kind of remove them all. I’m just kind of curious if they have anything to do with what’s happening. Just to kind of just isolate the problem if possible. Yeah. See what happens.
+I don’t know what’s happening.
+Yeah. I don’t know what the research doesn’t automatically.
+I guess so. Yeah.
+Yeah. So we’re not happy with the performance of the role screen for this guy.
+With this IT infrastructure background and very senior management, he was a major in the army.
+But we’re getting roles that don’t seem to relate to any of his experience or preferences, which is unfortunate. So we need to fix that. I don’t know if the role screen is so far we’ve just kind of tailored it to a couple of resumes.
+My resume, which is heavy with AI stuff and your resume, which is recruiting and marketing and stuff. So yeah, we need to make sure it works for this guy. And then we’ll just, I mean, ideally, like you said, it would be nice to work for all kinds of different people, but the only way to test it is one resume at a time. That’s why it’ll be nice to have our beta testers but we’re not quite ready for that because we don’t want them having this experience. That should at least be like close to working. So scroll down and see what’s going on. I think it’s done with whatever it’s going to do. Architectural product designer.
+Senior financial analyst. Benefits partner.
+Oh, it hasn’t changed. Okay.
+There’s no refresh button?
+Scroll back up I think there is a refresh button.
+Yeah. I just took it out. I just took it out.
+Yeah. Maybe I’ll.
+So when you click refresh roles, all of the matched roles should maybe disappear.
+Yeah. Because it’s keeping all the other ones.
+It’s finding matched roles, but I don’t know if it’s removing the ones that are there. It’s just creating a new list and putting it on top.
+Well, go ahead and pick some of these roles. Put them in the preferred list so we can check some other screens because we’ve established there are issues.
+You haven’t added any preferred roles. I know that none of them fit him, but just for the sake of testing other screens and not getting stuck on this one problem.
+Okay. I’m going to do a business intelligence preferred.
+I’m going to be cost Part-time editor.
+AI GTM leader. That’s where associate director.
+Associate store director.
+Business development lead.
+Yeah.
+I’ll put IT technical product.
+Channel resolutions manager.
+Associate store director.
+Or it doesn’t matter. We’re just doing it to test other screens. We’re not. None of these are any good for him anyway, so. They’re all like equally bad.
+So just yeah, just go up there and randomly give them some stars and some ranks so that we can test those things and we can move on to the next screens.
+We’re just trying to make some progress with our app testing. So we can find other bugs to fix, you know?
+Yeah.
+And then I guess rank them however doesn’t matter.
+Okay.
+You didn’t rank any of them. You just gave them stars.
+Oh, I didn’t rank them? Oh, I was giving stars? Okay. I ranked them. Well, I’m going to do the.
+So you can sort them by rank later. Like right now you can sort by number of stars. But if you do it, now you can sort by rank if you give them all a rank.
+Oh.
+Rank is more specific because you can each one only gets its dedicated rank, whereas stars you can have a whole bunch that are five stars and then there’s no particular order to them.
+Like if it were me and I had my 800 roles in there or whatever, I’d be like, you know, I’d only, I might have a whole bunch that are five star, but I’d only have one that’s number one, you know?
+But I may not really like how I ranked them because it’s too much work. So I might stick with the preferences and just do all the five-star ones because I don’t care. They’re all good, you know?
+All right
+I’m going to sort sorting methods as well. So you don’t spend all your time looking at the wrong ones.
+I like that it’s giving you salaries for those. That’s good. Something’s working.
+Yeah. That’s a good thing.
+Okay. So go ahead and run the gap analysis. See if that’s working.
+We’re going to find issues. It’s okay.
+That’s what we’re doing. Fixing them.
+Is that what goes? Even with my job, we find all kinds of stuff. So we’ve got two jobs with major gaps, one job with minor gaps, and one job with my moderate gaps.
+One with minor gaps is the business intelligence and insights analyst.
+We go ahead and see what those are if you want.
+It’s got zero resume gaps. About that.
+So that’s weird because so yeah, we’re on the gap screen, Mr. Transcript. And we are seeing zero resume gaps for a job that definitely has gaps. We’re looking at a business intelligence and insights analyst marketing analytics role for Elastic. And the resume on file is IT infrastructure senior manager. But there’s no way that resume matches the job. So the resume gaps isn’t doing a very good job. It’s not showing. It’s not populating well for the gaps. So that needs to be checked. And fixed.
+For the personality gaps, it’s probably fine. For the preference gaps, location preference mismatch you selected Georgia. But this job appears to be in the United States.
+I mean, okay, I think most people who use this app will be in the United States. At least for now. I don’t think we’re going to get a whole bunch of people from Georgia, the country. So I wouldn’t assume that Georgia is although Georgia, the country, like does the job just check it real quick. I’m curious if that’s a bug or if it’s actually accurate.
+No, no. I’m going to pick it. It can’t be.
+Go back. You don’t know. There’s jobs in other countries on our list. Databricks, where are they located? United States. What’s the next one? Associate director.
+United States. What’s the customer of the solutions manager?
+Yeah, I don’t know
+Newark California.
+Huh Okay, whatever. There’s no Georgia job. What’s it even talking about?
+I put in I wanted to be in Georgia, Atlanta. Atlanta, Georgia, not the country of Georgia.
+And they’re like, well, it looks like a mismatch because you selected Georgia.
+Well, I would go back to. The preferences and get rid of that. Are you going to keep running into it?
+So well, it’s also a country.
+There’s a country called Georgia.
+It says it’s a state. Have you assumed it is a United States? What state?
+Oh, that’s an app glitch. So if they select the US, the US state, Georgia, it shouldn’t be saying like it shouldn’t be saying that you selected Georgia, but this job is in the United States. And then filter out all those jobs. I wonder if that has something to do with it. Can you get rid of the Georgia thing for now just to test it?
+Maybe that’s getting in the way of his roles.
+Maybe he’s looking for jobs like in Georgia, the country.
+I didn’t put US only
+Yeah, yeah. Well, it’s not perfect yet. We’re still working on it. It’s like do that. We’re testing things. I’m not trying to prove that it works. I’m trying to figure out where it doesn’t. So get rid of the thing. Then select the state. Just pick a different state. Just for the fuck of it.
+Where is he Is he actually in Georgia?
+I don’t know
+Is he in Georgia, the state?
+Yeah, he’s in the state. He’s in Atlanta, Georgia again.
+It’s Atlanta.
+I noticed a lot of job apps will put the main city like the nearest city. I wanted to say what state. It’ll say like Atlanta, Georgia. It’ll say like Portland, Oregon. And it’ll be like San Francisco, California, Los Angeles, California. And have like a few cities in California. Like because they’re like not just the state, right?
+You can’t just put the state. Yeah, you got to have cities.
+The nearest city So instead of United States, what state on the preferences page we should put city-state combos, nearest instead of saying United States.
+Oh, like yeah, like the nearest metropolitan city kind of thing.
+There you go. That’s maybe just say that. Nearest metropolitan city. And then yeah, or nearest city.
+Because that’s what they’re always doing. You know, it’s Denver, Colorado.
+Charleston, South Carolina. It’s Dallas, Texas.
+Yeah, there’s a big difference between like Dallas and Austin, Texas. They’re not close to each other. And you know, Sacramento, I mean, not Sacramento, but San Antonio, Texas, is pretty far. Well, it’s maybe two and a half to three hours from Austin. But then Dallas is like five hours from there, right? Lubbock is like super far. So like, yeah, it matters. So yeah, instead of state, it should be like nearest city. That would make more sense. It actually, like if you were in Vancouver, Washington, you could drive to Portland in half an hour. Portland, Oregon.
+Yeah, but still, it’s got to be the biggest city or the most well-known city or like the metropolitan city. Like if I told you South Carolina and then I said, you know, Bakersfield, South Carolina, or what the fuck that is, you know, you know, Charleston, South Carolina, it’s like a major city. People recognizable.
+No, what I’m trying to say is it should be multiple big cities within each state.
+Oh, multiple big cities in each state.
+Well, yeah, because Austin, Texas, and Dallas, Texas are two completely different regions.
+San Francisco, California, and Los Angeles, California are like five hours from each other. Right?
+But Vancouver, Washington, and Portland, Oregon are 30 minutes away from each other. And they’re two different states. So the state isn’t that helpful. What helps is knowing the major city that it’s next to. So you don’t want I wouldn’t look for if I was willing to travel, which I don’t really see the point, because there’s enough remote jobs. But if I was willing to go, I definitely wouldn’t be willing to move to Dallas.
+I would be willing to go to Austin.
+Right So I don’t want it to list 100 jobs for Dallas because there’s plenty of jobs and they pay well. But I’m not going to Dallas.
+It’s super far. And like, it’s two Republican. You know? I wouldn’t go there. Austin is Austin’s like way liberal. The cost of living just got super high because all the LA people moved there. But it’s like, you know, it’s always been super liberal city for Texas. Austin does. So I mean, I would just much rather move to Austin. I would be if I found a good enough job there, I’d be like, sure, I’ll go. Right? Because that’s a place we wouldn’t want to be.
+Well,
+what I know about you all is you like the arts, too. You like art, you know, art and creative people. And those kinds of people. That’s all like that’s all Austin, right?
+Yeah, yeah, the big city We go to ACL like pretty often. Like we’ve been like four times with our kids.
+Austin City Limits is like a big concert festival and all the musicians come.
+Yeah, I want to go there. I’ve never been to that. You know.
+Yeah, it’s fun It was cheaper when the kids were young enough to get in free, but now they have to pay for all of them, so. It’s okay.
+Yeah, I’m getting pretty tired. I got to go.
+Okay, so anyways, we need to fix the preferences screen so that instead of United States, what state it needs to say nearest metropolitan area. And it needs to have all the metropolitan areas some states will have two or three some states will have one or two.
+But yeah, there needs to be at least one major metropolitan area per state. And for California, you should have like probably three minimum, right? And then Texas will need probably three at least San Antonio, Austin, and Dallas. Those are like the three major ones, but maybe Lubbock, too. Even though Lubbock’s not that big, it’s pretty far from the others. There’s also like El Paso, which is another one. In Texas. So it needs like plenty of metropolitan areas.
+And then then when it won’t be like, oh, you said Georgia. You’re in another country. It won’t be stupid.
+But let’s go back to so you put it in Idaho. I want you to do a quick test before it sounds like you’re getting tired and I’m I’ve been too zoned into my work to like think straight. And then the kids are telling me it’s time for dinner. So go to roles or go ahead and save and continue first.
+Yeah.
+And then it’s saving. So hopefully then click roles.
+And I guess like refresh the key frame over here. Huh?
+Checking out over here with the keywords and then.
+It’s already refreshing, I guess.
+So the keyword it’s always refreshing in this area. Like constantly refreshing.
+Well, it refreshes when you load the screen. Or when you update the keywords.
+Yeah.
+It’s a little annoying. Only because it shouldn’t refresh just because you clicked on one of the keywords.
+I get it when you load the screen. No reason for it to wait, but you might be wanting to select more. Oh, it’s getting better. Look at that. Director of Global Communications and Social Media is not perfect. Account Manager is still kind of like sales. Director of Content Management.
+Yeah.
+Still shitty. It’s funny it’s giving you Georgia.
+Boss Manager. Commercial Account Manager. Technical Accounting.
+IT Infrastructure What are these guys doing?
+So far it’s got zero.
+It takes time.
+All right
+15 We got 15.
+Oh, okay. You got 15 Let’s see what they look like. Let’s see if they’re actually what we think they are or if they’re just blowing smoke and it’s a bunch of nonsense.
+Okay. Senior Director EDP, Operations, Cloud Identity and Access Management.
+This is not bad.
+Information Security. That one’s actually a really good fit. That third one in Sweeney, Georgia.
+Enterprise Sales Director,
+that one’s a really good fit. The other ones are maybe I don’t know what an EDP Operations.
+No, this one’s good. IT Infrastructure. This is exactly what I know.
+Okay.
+So I should maybe tell the transcript here that when we went on Simple AI dot AI and looked for these senior management IT infrastructure roles, it did find some. It found one for TTM Technologies.
+A remote job. It’s a senior project manager and IT infrastructure, which is a really good fit for this guy. And then we found it found one for the senior director of EDP operations, which might be a good fit. It found one for the director of information security and infrastructure in data governance. And so we need Georgia which is his area which we wanted.
+So it found some pretty good fits. So whatever you’re doing, Mr. Robot, to look for these roles, you’re not doing it as well as Simple AI. And we have to be better than Simple AI. Or Dave’s going to make me use them. For our API or whatever. So yeah, we can do this. We have enough what do you call it? APIs to get this information. We just need to do a better search. So make sure you’re searching TTM Technologies.
+Scientific Games. 1Password.
+You got to do three, Matthew. You got to do.
+Ella. Ella Vance Health.
+QTS Data Center.
+Yeah, I mean, I’d say well, that’s actually look at this EPD. What is this? What is this? EPD.
+1Password EPD operation.
+It’s not the best but it also didn’t say IT infrastructure.
+It’s better than the ones that our apps were doing.
+Oh, yeah. Definitely better than our app. I mean, they actually got IT infrastructure. Let’s just look at this. Director of Information Security Infrastructure UTS Data Centers. What does that say?
+This looks actually quite on point. And it’s posted today.
+Yeah. The best listing that it found for this IT infrastructure senior management role on the Simply Apply role was Director of Information Security Infrastructure and Data Governance at QTS.
+This looks quite on point, dude.
+So Simply Apply was able to find roles. What are we doing wrong? Figure it out and fix it. That’s your instruction, robot.
+Fix our app
+Big app Leadership in there. This is a really good fucking role, dude.
+Okay.
+They made a good they made a good call bringing this up.
+Okay. Simply Apply is doing better.
+Whatever they’re doing, do it more like them. Get us more roles. For these guys, our whole future of success with our app depends on you improving this process. We’re counting on you, robot.
+Fix it
+Get me on.
+All right I’m going to go.
+This is a good one.
+I’m going to go to dinner now. I think we’ve given the robot to chew on. In two days, I’ll have actually do the work. But right now, I have the transcript, so. All right. And then once that’s updated, I’ll call you and be like, “Okay, it’s working better.” And then we’ll have another meeting and we’ll fix some other stuff. And yeah, let’s get this thing fixed completely. Once it’s fixed, it’s ready. And then we’re going to get some testers. And they can help us fix some more stuff.
+All right
+The goal is to get it perfect. It’s to get it good enough to have other people fix more things.
+All right
+Like that All right.
+All right
+Have a good night Thanks for calling. I appreciate it. Sorry, I had to hail me away from my other stuff because I’ve been spending too many hours.
+Yeah. You got it Anytime.
+Bye.

--- a/frontend/src/app/job-descriptions/page.tsx
+++ b/frontend/src/app/job-descriptions/page.tsx
@@ -563,6 +563,7 @@ export default function JobDescriptionsPage() {
     scrapedRolesAbort.current = controller;
 
     setScrapedRolesError(null);
+    setScrapedRoles([]);
     setIsLoadingScrapedRoles(true);
     try {
       const buildParams = (opts?: { simple?: boolean }) => {
@@ -665,12 +666,13 @@ export default function JobDescriptionsPage() {
 
   useEffect(() => {
     if (!hasMounted) return;
+    if (hasEverLoadedRoles) return;
     const t = window.setTimeout(() => {
       loadScrapedRoles();
     }, 800);
     return () => window.clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasMounted, positiveKeywords, negativeKeywords]);
+  }, [hasMounted]);
 
   const importFromUrl = async (raw: string, opts?: { clearImporterInput?: boolean; seedImporterInput?: boolean }) => {
     const rawUrl = String(raw || "").trim();

--- a/frontend/src/app/job-preferences/page.tsx
+++ b/frontend/src/app/job-preferences/page.tsx
@@ -18,6 +18,7 @@ interface JobPreferences {
   minimumSalary: string;
   jobSearchStatus: string;
   state?: string;
+  metroAreas?: string[];
 }
 
 interface BackendJobPreferences {
@@ -33,6 +34,7 @@ interface BackendJobPreferences {
   minimum_salary: string;
   job_search_status: string;
   state?: string;
+  metro_areas?: string[];
   user_mode?: string;
 }
 
@@ -93,7 +95,7 @@ const ROLE_CATEGORIES = [
   "Coaching & Mentorship",
 ];
 
-const LOCATION_PREFERENCES = ["In-Person", "Hybrid", "Remote"];
+const LOCATION_PREFERENCES = ["In-Person", "Hybrid", "Remote (US only)", "Remote (Worldwide)"];
 
 const WORK_TYPE = ["In-Person", "Hybrid", "Remote"];
 
@@ -154,57 +156,62 @@ const JOB_SEARCH_STATUS = [
   "Not looking and closed to offers",
 ];
 
-const US_STATES = [
-  "Alabama",
-  "Alaska",
-  "Arizona",
-  "Arkansas",
-  "California",
-  "Colorado",
-  "Connecticut",
-  "Delaware",
-  "Florida",
-  "Georgia",
-  "Hawaii",
-  "Idaho",
-  "Illinois",
-  "Indiana",
-  "Iowa",
-  "Kansas",
-  "Kentucky",
-  "Louisiana",
-  "Maine",
-  "Maryland",
-  "Massachusetts",
-  "Michigan",
-  "Minnesota",
-  "Mississippi",
-  "Missouri",
-  "Montana",
-  "Nebraska",
-  "Nevada",
-  "New Hampshire",
-  "New Jersey",
-  "New Mexico",
-  "New York",
-  "North Carolina",
-  "North Dakota",
-  "Ohio",
-  "Oklahoma",
-  "Oregon",
-  "Pennsylvania",
-  "Rhode Island",
-  "South Carolina",
-  "South Dakota",
-  "Tennessee",
-  "Texas",
-  "Utah",
-  "Vermont",
-  "Virginia",
-  "Washington",
-  "West Virginia",
-  "Wisconsin",
-  "Wyoming",
+const US_METRO_AREAS = [
+  "Atlanta, GA",
+  "Austin, TX",
+  "Baltimore, MD",
+  "Birmingham, AL",
+  "Boise, ID",
+  "Boston, MA",
+  "Buffalo, NY",
+  "Charlotte, NC",
+  "Chicago, IL",
+  "Cincinnati, OH",
+  "Cleveland, OH",
+  "Columbus, OH",
+  "Dallas, TX",
+  "Denver, CO",
+  "Des Moines, IA",
+  "Detroit, MI",
+  "El Paso, TX",
+  "Hartford, CT",
+  "Honolulu, HI",
+  "Houston, TX",
+  "Indianapolis, IN",
+  "Jacksonville, FL",
+  "Kansas City, MO",
+  "Las Vegas, NV",
+  "Los Angeles, CA",
+  "Louisville, KY",
+  "Memphis, TN",
+  "Miami, FL",
+  "Milwaukee, WI",
+  "Minneapolis, MN",
+  "Nashville, TN",
+  "New Orleans, LA",
+  "New York, NY",
+  "Oklahoma City, OK",
+  "Omaha, NE",
+  "Orlando, FL",
+  "Philadelphia, PA",
+  "Phoenix, AZ",
+  "Pittsburgh, PA",
+  "Portland, OR",
+  "Providence, RI",
+  "Raleigh, NC",
+  "Richmond, VA",
+  "Sacramento, CA",
+  "Salt Lake City, UT",
+  "San Antonio, TX",
+  "San Diego, CA",
+  "San Francisco, CA",
+  "San Jose, CA",
+  "Seattle, WA",
+  "St. Louis, MO",
+  "Tampa, FL",
+  "Tucson, AZ",
+  "Virginia Beach, VA",
+  "Washington, DC",
 ];
 
 export default function JobPreferencesPage() {
@@ -224,6 +231,7 @@ export default function JobPreferencesPage() {
     minimumSalary: "",
     jobSearchStatus: "",
     state: "",
+    metroAreas: [],
   });
   const [lastSaved, setLastSaved] = useState<string | null>(null);
   const [helper, setHelper] = useState<JobPreferencesResponse["helper"] | null>(null);
@@ -241,13 +249,16 @@ export default function JobPreferencesPage() {
       const cached = localStorage.getItem("job_preferences");
       if (cached) {
         const parsed = JSON.parse(cached);
-        // Only keep state when the UI could have collected it (In-Person selected).
         const locs = Array.isArray(parsed?.locationPreferences) ? parsed.locationPreferences : [];
-        const hasInPerson = locs.includes("In-Person");
+        const hasInPerson = locs.includes("In-Person") || locs.includes("Hybrid");
+        // Migrate old "Remote" to "Remote (US only)"
+        const migratedLocs = locs.map((l: string) => l === "Remote" ? "Remote (US only)" : l);
         setPreferences({
           ...parsed,
+          locationPreferences: migratedLocs,
           locationText: String(parsed?.locationText || ""),
           state: hasInPerson ? String(parsed?.state || "") : "",
+          metroAreas: Array.isArray(parsed?.metroAreas) ? parsed.metroAreas : [],
         });
       }
     } catch {
@@ -262,13 +273,13 @@ export default function JobPreferencesPage() {
         );
         if (resp.preferences) {
           const p = resp.preferences;
-          const hasInPerson = Array.isArray(p.location_preferences)
-            ? p.location_preferences.includes("In-Person")
-            : false;
+          const locs = Array.isArray(p.location_preferences) ? p.location_preferences : [];
+          const hasInPerson = locs.includes("In-Person") || locs.includes("Hybrid");
+          const migratedLocs = locs.map((l: string) => l === "Remote" ? "Remote (US only)" : l);
           const mapped: JobPreferences = {
             values: p.values || [],
             roleCategories: p.role_categories || [],
-            locationPreferences: p.location_preferences || [],
+            locationPreferences: migratedLocs,
             locationText: String((p as any)?.location_text || ""),
             workType: p.work_type || [],
             roleType: p.role_type || [],
@@ -278,6 +289,7 @@ export default function JobPreferencesPage() {
             minimumSalary: p.minimum_salary || "",
             jobSearchStatus: p.job_search_status || "",
             state: hasInPerson ? (p.state || "") : "",
+            metroAreas: Array.isArray(p.metro_areas) ? p.metro_areas : [],
           };
           setPreferences(mapped);
         }
@@ -327,10 +339,14 @@ export default function JobPreferencesPage() {
         ? currentValues.filter((v) => v !== value)
         : [...currentValues, value];
 
-      // If In-Person is not selected, clear state to avoid confusing downstream steps.
       if (field === "locationPreferences") {
-        const hasInPerson = newValues.includes("In-Person");
-        return { ...prev, [field]: newValues, state: hasInPerson ? (prev.state || "") : "" };
+        const hasInPerson = newValues.includes("In-Person") || newValues.includes("Hybrid");
+        return {
+          ...prev,
+          [field]: newValues,
+          state: hasInPerson ? (prev.state || "") : "",
+          metroAreas: hasInPerson ? (prev.metroAreas || []) : [],
+        };
       }
 
       return { ...prev, [field]: newValues };
@@ -360,6 +376,7 @@ export default function JobPreferencesPage() {
         minimum_salary: preferences.minimumSalary,
         job_search_status: preferences.jobSearchStatus,
         state: preferences.state,
+        metro_areas: preferences.metroAreas,
         user_mode: mode,
       };
       const res = await api<JobPreferencesResponse>(
@@ -489,25 +506,38 @@ export default function JobPreferencesPage() {
                   </div>
                 </div>
 
-                {preferences.locationPreferences.includes("In-Person") && (
+                {(preferences.locationPreferences.includes("In-Person") || preferences.locationPreferences.includes("Hybrid")) && (
                   <div>
                     <h3 className="text-lg font-medium mb-3">
-                      United States - what state?
+                      Nearest metropolitan area(s)
                     </h3>
-                    <select
-                      value={preferences.state || ""}
-                      onChange={(e) =>
-                        handleSingleSelect("state", e.target.value)
-                      }
-                      className="w-full max-w-xs border border-gray-300 rounded-md px-3 py-2"
-                    >
-                      <option value="">Select a state</option>
-                      {US_STATES.map((state) => (
-                        <option key={state} value={state}>
-                          {state}
-                        </option>
+                    <p className="text-sm text-white/70 mb-3">
+                      Select all metro areas you&apos;d consider working in.
+                    </p>
+                    <div className="grid grid-cols-2 md:grid-cols-3 gap-2 max-h-64 overflow-y-auto rounded-md border border-white/10 bg-black/10 p-3">
+                      {US_METRO_AREAS.map((metro) => (
+                        <label
+                          key={metro}
+                          className="flex items-center space-x-2 cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={(preferences.metroAreas || []).includes(metro)}
+                            onChange={() => {
+                              setPreferences((prev) => {
+                                const current = prev.metroAreas || [];
+                                const next = current.includes(metro)
+                                  ? current.filter((m) => m !== metro)
+                                  : [...current, metro];
+                                return { ...prev, metroAreas: next };
+                              });
+                            }}
+                            className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                          />
+                          <span className="text-sm">{metro}</span>
+                        </label>
                       ))}
-                    </select>
+                    </div>
                   </div>
                 )}
               </div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -67,6 +67,27 @@ export default function LoginPage() {
 
   const primaryCta = useMemo(() => (mode === "login" ? "Log in" : "Create account"), [mode]);
 
+  function clearUserLocalStorage() {
+    const keysToRemove = [
+      "rf_user",
+      "job_preferences",
+      "job_preferences_helper",
+      "resume_extract",
+      "job_descriptions",
+      "personality_profile",
+      "personality_assessment",
+      "roleferry-progress",
+      "tracker_applications",
+      "scraped_roles_cache",
+      "rf_auto_roles_positive_keywords_v1",
+      "rf_auto_roles_negative_keywords_v1",
+      "selected_job_description",
+    ];
+    for (const key of keysToRemove) {
+      try { localStorage.removeItem(key); } catch {}
+    }
+  }
+
   async function submit() {
     setError(null);
     setLoading(true);
@@ -78,6 +99,7 @@ export default function LoginPage() {
         if (password.length < 8) throw new Error("Password must be at least 8 characters.");
         if (password !== password2) throw new Error("Passwords do not match.");
 
+        clearUserLocalStorage();
         const resp = await api<any>("/auth/register", "POST", {
           email,
           password,
@@ -93,6 +115,7 @@ export default function LoginPage() {
         if (!email.trim()) throw new Error("Email is required.");
         if (!password) throw new Error("Password is required.");
 
+        clearUserLocalStorage();
         const resp = await api<any>("/auth/login", "POST", { email, password });
         if (!resp?.success) throw new Error(resp?.message || "Failed to log in.");
         if (resp?.user) localStorage.setItem("rf_user", JSON.stringify(resp.user));

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -29,6 +29,20 @@ export default function Navbar() {
     if (saved) {
       try { setUser(JSON.parse(saved)); } catch {}
     }
+
+    (async () => {
+      try {
+        const resp = await api<any>("/auth/me", "GET");
+        if (resp?.user) {
+          const serverUser = resp.user;
+          const localUser = saved ? JSON.parse(saved) : null;
+          if (!localUser || localUser.id !== serverUser.id) {
+            localStorage.setItem("rf_user", JSON.stringify(serverUser));
+            setUser(serverUser);
+          }
+        }
+      } catch {}
+    })();
   }, []);
 
   // Mark steps complete even if the user navigates via the navbar (not the dashboard stones).


### PR DESCRIPTION
- Fix account caching bug: clear user-specific localStorage on login/register, verify session against /auth/me in Navbar to prevent stale user display
- Split "Remote" into "Remote (US only)" and "Remote (Worldwide)" options with automatic migration of old "Remote" values
- Replace US states dropdown with 55 metro area checkboxes (multi-select) for more granular location preferences
- Fix Georgia location bug: generic US locations no longer flag as mismatches, metro area matching checks city name and state abbreviation
- Fix refresh roles: clear old results immediately when refresh starts
- Fix keyword auto-refresh: initial load only, manual "Refresh Roles" after
- Add week 22 meeting transcript