### PR TITLE
Week 22 fixes: message quality, contact search, offer screen, campaign output

### DIFF
--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -272,7 +272,7 @@ async def analytics_explain(http_request: Request):
             "Verification is strong; maintain list hygiene to protect deliverability.",
         ],
         "risks": [
-            "Some variants are underperforming—subject lines may be too generic.",
+            "Some variants are underperforming -subject lines may be too generic.",
             "If verified_ratio drops, expect bounce rate and spam placement to worsen.",
         ],
         "next_actions": [

--- a/backend/app/routers/bio_pages.py
+++ b/backend/app/routers/bio_pages.py
@@ -216,7 +216,7 @@ def _build_deterministic_draft(
 
     # Keep the public bio reusable across many applications.
     # Never shape the headline around one selected role.
-    headline = f"{display_name} — job seeker bio page"
+    headline = f"{display_name} - job seeker bio page"
 
     subheadline = "A concise overview of experience, proof points, and fit."
     if tone_hint:
@@ -230,7 +230,7 @@ def _build_deterministic_draft(
                 metric = str(m.get("metric") or "").strip()
                 value = str(m.get("value") or "").strip()
                 ctx = str(m.get("context") or "").strip()
-                line = " — ".join([p for p in [metric, value] if p])
+                line = ", ".join([p for p in [metric, value] if p])
                 if ctx:
                     line = f"{line} ({ctx})" if line else ctx
                 if line:
@@ -481,7 +481,7 @@ async def generate_video_script(payload: GenerateVideoScriptRequest, http_reques
             if isinstance(m0, dict):
                 metric = str(m0.get("metric") or "").strip()
                 value = str(m0.get("value") or "").strip()
-                metric_line = " — ".join([x for x in [metric, value] if x]).strip()
+                metric_line = ", ".join([x for x in [metric, value] if x]).strip()
             else:
                 metric_line = str(m0).strip()
         pm0 = pms[0] if (isinstance(pms, list) and pms and isinstance(pms[0], dict)) else {}
@@ -491,7 +491,7 @@ async def generate_video_script(payload: GenerateVideoScriptRequest, http_reques
 
         fallback = "\n".join(
             [
-                f"Hi{', ' + first if first else ''} — I’m {display_name}.",
+                f"Hi{‘, ‘ + first if first else ‘’} - I’m {display_name}.",
                 "I build and lead work that drives outcomes, and I am exploring roles where I can make a measurable impact.",
                 (f"A recent win: {metric_line}." if metric_line else "A recent win: I’ve delivered measurable improvements across teams and systems."),
                 (f"I’m especially strong at tackling problems like: {pain}." if pain else "I’m especially strong at tackling messy, high-impact problems and turning them into clear execution plans."),
@@ -527,7 +527,7 @@ async def generate_video_script(payload: GenerateVideoScriptRequest, http_reques
                     "IMPORTANT:\n"
                     "- This bio page is reusable across multiple companies: DO NOT mention any specific employer.\n"
                     "- Use ONLY the provided JSON; do not invent facts or numbers.\n"
-                    "- Keep it ~60 seconds when read aloud (roughly 110–160 words).\n"
+                    "- Keep it ~60 seconds when read aloud (roughly 110-160 words).\n"
                     "- Keep sentences short and natural.\n"
                     "Return ONLY JSON: { script: string }"
                 ),

--- a/backend/app/routers/bio_pages.py
+++ b/backend/app/routers/bio_pages.py
@@ -396,23 +396,30 @@ async def generate_bio_page(payload: GenerateBioPageRequest, http_request: Reque
 @router.post("/bio-pages/publish", response_model=PublishBioPageResponse)
 async def publish_bio_page(payload: PublishBioPageRequest, http_request: Request):
     try:
+        import hashlib
+
         user = await get_current_user_optional(http_request)
         user_id = user.id if user else "anon"
+        user_email = str(getattr(user, "email", "") or "").strip()
 
-        # Ensure storage exists
         if not hasattr(store, "bio_pages_by_slug"):
             store.bio_pages_by_slug = {}  # type: ignore[attr-defined]
+        if not hasattr(store, "bio_slug_by_user"):
+            store.bio_slug_by_user = {}  # type: ignore[attr-defined]
 
-        slug_base = _safe_slug(
-            payload.slug_hint
-            or payload.draft.display_name
-            or (str(getattr(user, "email", "")) if user else "")
-            or "bio"
-        )
-        slug = slug_base
-        # Uniqueness
-        while slug in store.bio_pages_by_slug:  # type: ignore[attr-defined]
-            slug = f"{slug_base}-{uuid.uuid4().hex[:6]}"
+        existing_slug = store.bio_slug_by_user.get(user_id)  # type: ignore[attr-defined]
+        if existing_slug and isinstance(existing_slug, str):
+            slug = existing_slug
+        else:
+            name_part = _safe_slug(
+                payload.slug_hint
+                or payload.draft.display_name
+                or user_email
+                or "bio"
+            )
+            uid_hash = hashlib.sha256(user_id.encode()).hexdigest()[:8]
+            slug = f"{name_part}-{uid_hash}"
+            store.bio_slug_by_user[user_id] = slug  # type: ignore[attr-defined]
 
         record = {
             "slug": slug,

--- a/backend/app/routers/campaign.py
+++ b/backend/app/routers/campaign.py
@@ -1118,41 +1118,62 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
                 subj = "Closing the loop?"
 
             rb = _build_research_brief(ctx)
-            company_sig = ((rb.get("company_signals") or [None])[0] if isinstance(rb, dict) else None) or None
-            role_sig = ((rb.get("role_scope_signals") or [None])[0] if isinstance(rb, dict) else None) or None
+
+            def _strip_signal_label(s: str) -> str:
+                """Remove internal labels like 'Company theme signal:', 'Market position:', etc."""
+                t = str(s or "").strip()
+                t = re.sub(r"^(Company theme signal|Market position|Products?/launches?|Hiring signal|Recent post|Publication|Role success metric|Role required skill|Profile highlight|Posts about|Interesting fact|Theme):\s*", "", t, flags=re.I)
+                return t.strip()
+
+            raw_company_sig = ((rb.get("company_signals") or [None])[0] if isinstance(rb, dict) else None) or ""
+            raw_role_sig = ((rb.get("role_scope_signals") or [None])[0] if isinstance(rb, dict) else None) or ""
+            company_sig = _strip_signal_label(raw_company_sig)
+            role_sig = _strip_signal_label(raw_role_sig)
             cta_line = chosen_cta or "Open to a quick 10-15 minute chat?"
+
+            offer_ctx = ctx.get("offer") if isinstance(ctx, dict) else {}
+            one_liner = str((offer_ctx or {}).get("one_liner") or "").strip()
+            proof_points = [str(p).strip() for p in _as_list((offer_ctx or {}).get("proof_points"))[:2] if str(p).strip()]
 
             body_bits: List[str] = [f"Hi {greet_name},\n\n"]
             if step == 1:
                 if company_sig:
-                    body_bits.append(f"I'm reaching out after learning about {company_name or 'your team'}'s work. {company_sig}\n\n")
+                    body_bits.append(f"I noticed {company_name or 'your team'} {company_sig[0].lower()}{company_sig[1:].rstrip('.')}. " if company_sig and len(company_sig) > 5 else f"I noticed {company_name or 'your team'} is doing interesting work. ")
+                    if one_liner:
+                        body_bits.append(f"{one_liner.rstrip('.')}. ")
+                    if proof_points:
+                        body_bits.append(f"For example, {proof_points[0][0].lower()}{proof_points[0][1:].rstrip('.')}.")
+                    body_bits.append(f"\n\n{cta_line}\n\n")
                 elif role_sig:
-                    body_bits.append(f"I noticed {company_name or 'your team'} is looking for a {job_title or 'new team member'}. {role_sig}\n\n")
+                    body_bits.append(f"I noticed the {job_title or 'role'} at {company_name or 'your team'} and wanted to introduce myself. ")
+                    if one_liner:
+                        body_bits.append(f"{one_liner.rstrip('.')}. ")
+                    body_bits.append(f"\n\n{cta_line}\n\n")
                 else:
-                    body_bits.append(f"I noticed the {job_title or 'role'} at {company_name or 'your team'} and wanted to introduce myself.\n\n")
-                offer_ctx = ctx.get("offer") if isinstance(ctx, dict) else {}
-                one_liner = str((offer_ctx or {}).get("one_liner") or "").strip()
-                if one_liner:
-                    body_bits.append(f"{one_liner}\n\n")
-                body_bits.append(f"{cta_line}\n\n")
+                    body_bits.append(f"I noticed the {job_title or 'role'} at {company_name or 'your team'} and wanted to introduce myself. ")
+                    if one_liner:
+                        body_bits.append(f"{one_liner.rstrip('.')}.")
+                    body_bits.append(f"\n\n{cta_line}\n\n")
             elif step == 2:
                 body_bits.append(f"Just a quick follow-up on my previous note about the {job_title or 'role'}. I'm still very interested and would be glad to speak briefly if the role is still open.\n\n")
                 body_bits.append(f"{cta_line}\n\n")
             elif step == 3:
                 body_bits.append(f"I wanted to share a few highlights from my work that align with what teams typically need in a {job_title or 'role like this'}.\n\n")
-                body_bits.append("I'd be glad to explore how my background could support your team's goals.\n\n")
+                if proof_points:
+                    for pp in proof_points[:2]:
+                        body_bits.append(f"- {pp}\n")
+                    body_bits.append("\n")
                 body_bits.append(f"{cta_line}\n\n")
             else:
                 body_bits.append("I realize your time is limited, so this will be my final message. If the role has been filled or I'm not the right fit, no worries at all. If there's someone else I should speak with, I'd be grateful for an introduction.\n\n")
                 body_bits.append(f"{cta_line}\n\n")
 
-            # Optional: include bio/work links if provided in context
             bio = str(((links or {}).get("bio_page_url")) or "").strip()
             work = str(((links or {}).get("work_link")) or "").strip()
             if bio:
-                body_bits.append(f"Bio: {bio}\n")
+                body_bits.append(f"I put together a brief overview of my background here: {bio}\n")
             if work:
-                body_bits.append(f"Work: {work}\n")
+                body_bits.append(f"Work samples: {work}\n")
             body = _append_signature("".join(body_bits))
             return subj, body
 
@@ -1250,7 +1271,9 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
             "- Avoid startup jargon (e.g., 'ship outcomes', 'drive impact', 'move the needle'). Prefer human phrasing.\n"
             "- Voice must be first-person singular for an individual job seeker: use I/me/my, not we/us/our.\n"
             "- Use real names/companies ONLY if provided in the context JSON. Do not invent.\n"
-            "- Do NOT output template placeholders like {{first_name}}.\n\n"
+            "- Do NOT output template placeholders like {{first_name}}.\n"
+            "- NEVER include internal signal labels in the email body (e.g., 'Company theme signal:', 'Market position:', 'Profile highlight:', 'Theme:'). These are context for you, not email text.\n"
+            "- If a bio_page_url is provided in the links, include it with a brief intro like 'I put together a brief overview of my background here: [url]'. Do NOT just drop the URL without context.\n\n"
             f"Sequence step: {step} of 4.\n"
             f"Step intent: {step_intent}\n\n"
             f"{tone_line}\n"
@@ -1300,6 +1323,8 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
         data = extract_json_from_text(content_str) or {}
         subject = str(data.get("subject") or "").strip() or _fallback()[0]
         body = str(data.get("body") or "").strip() or _fallback()[1]
+
+        body = re.sub(r"(?:Company theme signal|Market position|Products?/launches?|Hiring signal|Recent post|Publication|Profile highlight|Posts about|Interesting fact|Theme):\s*", "", body, flags=re.I)
 
         # Enforce quality rules even if the model drifts.
         # IMPORTANT: Never return an email that is only a signature block.

--- a/backend/app/routers/context_research.py
+++ b/backend/app/routers/context_research.py
@@ -70,6 +70,15 @@ def _strip_likely_language(s: str) -> str:
     t = re.sub(r":\s*\n", ":\n", t)
     return t.strip()
 
+def _strip_urls(s: str) -> str:
+    t = str(s or "")
+    t = re.sub(r"\(https?://[^\s\)]+\)", "", t)
+    t = re.sub(r"https?://[^\s,\)\]]+", "", t)
+    t = re.sub(r"\(\s*\)", "", t)
+    t = re.sub(r"\s{2,}", " ", t)
+    return t.strip()
+
+
 # PDL runs whenever PDL_API_KEY is present. No separate gate needed.
 _ENABLE_PDL = True
 
@@ -692,25 +701,33 @@ def _cache_set(key: str, value: Dict[str, Any]) -> None:
 
 def _bullets_from_serper_hits(hits: Any, *, max_items: int = 6, label: str | None = None) -> str:
     """
-    Convert Serper hits into outreach-safe bullets with real URLs.
+    Convert Serper hits into outreach-safe bullets (no URLs in output).
     """
+    _GENERIC_TITLES = {
+        "about", "about us", "careers", "home", "contact", "team",
+        "leadership", "our team", "who we are", "company", "values",
+        "culture", "press", "newsroom", "blog", "jobs",
+    }
     out: List[str] = []
     try:
         for h in (hits or [])[: max(0, int(max_items))]:
             if not isinstance(h, dict):
                 continue
             title = str(h.get("title") or "").strip()
-            url = str(h.get("link") or h.get("url") or "").strip()
             snippet = str(h.get("snippet") or "").strip()
-            if not url:
-                continue
             if not title and not snippet:
                 continue
-            bit = title or snippet[:140]
-            if snippet and title and snippet.lower() not in title.lower():
-                bit = f"{title} — {snippet[:180]}"
-            # Keep it short; always include source URL.
-            out.append(f"- {bit} ({url})")
+            title_is_generic = any(
+                title.lower().startswith(g) or title.lower().rstrip(" .-") in _GENERIC_TITLES
+                for g in list(_GENERIC_TITLES) + ["about us -", "about -"]
+            ) if title else True
+            if snippet and (title_is_generic or not title):
+                bit = snippet[:220]
+            elif snippet and title:
+                bit = f"{title} - {snippet[:180]}"
+            else:
+                bit = title[:220]
+            out.append(f"- {bit}")
     except Exception:
         out = []
 
@@ -949,7 +966,7 @@ async def conduct_research(request: ResearchRequest):
             if not t:
                 return None
             # Try to extract a clear unit from common patterns like "Role, Unit" or "Role - Unit".
-            m = re.search(r"[,\\-–—]\\s*([A-Za-z][A-Za-z0-9 &/]+)$", t)
+            m = re.search(r"[,\\-- -]\\s*([A-Za-z][A-Za-z0-9 &/]+)$", t)
             if m:
                 candidate = m.group(1).strip()
                 if 3 <= len(candidate) <= 60:
@@ -982,7 +999,7 @@ async def conduct_research(request: ResearchRequest):
         is_big_company = company.lower() in BIG_COMPANIES
         org_unit = infer_org_unit(company, jd_title) if is_big_company else None
         scope_label = "division" if (is_big_company and org_unit) else "company"
-        scope_target = f"{company} — {org_unit}" if (scope_label == "division") else company
+        scope_target = f"{company}  - {org_unit}" if (scope_label == "division") else company
 
         # Build a *non-fabricated* research corpus.
         # - If data_mode == "live" and SERPER_API_KEY is set, we fetch web snippets via Serper.
@@ -1813,7 +1830,7 @@ async def conduct_research(request: ResearchRequest):
                 },
                 "theme": (
                     "Theme: What the company cares about: Reference a plausible priority (customer experience, reliability, speed, cost) "
-                    "and offer a 2–3 bullet mini-plan—without claiming a specific news event.\n"
+                    "and offer a 2-3 bullet mini-plan, without claiming a specific news event.\n"
                     "- Start with one concrete outcome tied to the role\n"
                     "- Propose a low-risk first sprint (instrument → ship → measure)\n"
                     "- Share a weekly reporting cadence"
@@ -1864,7 +1881,7 @@ async def conduct_research(request: ResearchRequest):
                 "hooks": [
                     "Connect the job’s top pain point to a specific outcome you’ve delivered before",
                     "Reference their org’s likely constraints (speed vs reliability vs cost) and offer a low-risk first step",
-                    "Offer a 2–3 bullet mini-plan tied to a KPI the role is accountable for",
+                    "Offer a 2-3 bullet mini-plan tied to a KPI the role is accountable for",
                 ],
             }
 
@@ -1876,7 +1893,7 @@ async def conduct_research(request: ResearchRequest):
         stub_json = {
             "research_by_contact": stub_research_by_contact,
             "hooks": [
-                "Open with a specific outcome you can improve in 2–3 weeks",
+                "Open with a specific outcome you can improve in 2-3 weeks",
                 "Reference a relevant initiative/news item as timing",
                 "Offer a concrete mini-plan instead of a generic pitch",
             ],
@@ -1901,13 +1918,14 @@ async def conduct_research(request: ResearchRequest):
                     "- Do NOT include meta/system disclaimers like '(no external lookup used)' in any user-facing text.\n"
                     "- If the corpus has limited data, you SHOULD still try:\n"
                     "  - Use general model knowledge to write a useful company description (what they sell, who they sell to, and the buying motion).\n"
-                    "  - Populate industry/size/headquarters/website/linkedin_url ONLY if you are confident (well-known company) — otherwise 'Unknown'.\n"
+                    "  - Populate industry/size/headquarters/website/linkedin_url ONLY if you are confident (well-known company)  - otherwise 'Unknown'.\n"
                     "  - Never invent specific numbers (revenue, headcount) or specific dates.\n"
                     "  - Never invent 'recent_news' URLs.\n"
                     "  - recent_news MUST be actual news items from the corpus web hits (with real URLs). If you don't have web sources, return recent_news: [].\n"
                     "  - company_market_position MUST be sourced from real web data. If no web sources, set company_market_position to an empty string ''.\n"
-                    "  - theme is NOT news. Always populate theme with safe, non-claiming outreach guidance using this exact sentence, then add a 2–3 bullet mini-plan:\n"
-                    "    \"Theme: What the company cares about: Reference a plausible priority (customer experience, reliability, speed, cost) and offer a 2–3 bullet mini-plan—without claiming a specific news event.\"\n"
+                    "  - theme is NOT news. Always populate theme with safe, non-claiming outreach guidance using this exact sentence, then add a 2-3 bullet mini-plan:\n"
+                    "    \"Theme: What the company cares about: Reference a plausible priority (customer experience, reliability, speed, cost) and offer a 2-3 bullet mini-plan -without claiming a specific news event.\"\n"
+                    "- NEVER include raw URLs in any prose/text field (company_culture_values, company_market_position, company_product_launches, company_leadership_changes, company_other_hiring_signals, company_recent_posts, company_publications, theme, bio). URLs belong ONLY in structured fields like recent_news[].url or signal_source. User-facing text must be clean prose with no URLs.\n"
                     "- If information is missing or uncertain, return EMPTY STRINGS (not placeholder text). NEVER write phrases like 'No data found', 'No product launch details captured', 'No leadership changes found', or any similar placeholder. Just return ''.\n"
                     "- shared_connections MUST be an empty array unless provided (it is empty in this corpus).\n\n"
                     "MINIMUM FACTS REQUIREMENT (critical):\n"
@@ -1921,17 +1939,17 @@ async def conduct_research(request: ResearchRequest):
                     "  Always populate interesting_facts with at least 3 items (inferred facts are OK when labeled as inferred).\n\n"
                     "Quality bar:\n"
                     "- NEVER use hedging words like 'likely', 'probably', 'may', 'might', 'appears to', 'seems to'. Write assertively or leave it out.\n"
-                    "- The company_summary.description should be 2–4 sentences and outreach-useful (what they do + why it matters + current priorities).\n"
-                    "- company_culture_values should be 4–8 sentences: how they operate + values signals (avoid claiming a specific internal culture doc).\n"
-                    "- company_market_position should be 4–8 sentences: who they compete with / positioning / what matters now.\n"
+                    "- The company_summary.description should be 2-4 sentences and outreach-useful (what they do + why it matters + current priorities).\n"
+                    "- company_culture_values should be 4-8 sentences: how they operate + values signals (avoid claiming a specific internal culture doc).\n"
+                    "- company_market_position should be 4-8 sentences: who they compete with / positioning / what matters now.\n"
                     "  - If you don't have sources, leave it empty.\n"
-                    "- company_product_launches should be 3–8 bullet points about recent launches/releases/announcements (with URLs if available in corpus).\n"
-                    "- company_leadership_changes should be 2–6 bullet points on exec/VP changes or notable leadership moves (with URLs if available in corpus).\n"
-                    "- company_other_hiring_signals should be 3–8 bullet points on hiring momentum signals beyond generic 'open roles' (with URLs if available).\n"
-                    "- company_recent_posts should be 3–8 bullets summarizing recent company posts (blog/press/LinkedIn topics) with URLs when available.\n"
-                    "- company_publications should be 1–6 bullets summarizing notable publications (case studies, whitepapers, reports) with URLs when available.\n"
-                    "- contact_bios.bio should be 1–2 sentences tailored to the contact's title/department.\n"
-                    "- contact_bios[].interesting_facts MUST have at least 3 items (aim for 5–6). Populate from these sources IN ORDER:\n"
+                    "- company_product_launches should be 3-8 bullet points about recent launches/releases/announcements. Do NOT include URLs in the text.\n"
+                    "- company_leadership_changes should be 2-6 bullet points on exec/VP changes or notable leadership moves. Do NOT include URLs in the text.\n"
+                    "- company_other_hiring_signals should be 3-8 bullet points on hiring momentum signals beyond generic 'open roles'. Do NOT include URLs in the text.\n"
+                    "- company_recent_posts should be 3-8 bullets summarizing recent company posts (blog/press/LinkedIn topics). Do NOT include URLs in the text.\n"
+                    "- company_publications should be 1-6 bullets summarizing notable publications (case studies, whitepapers, reports). Do NOT include URLs in the text.\n"
+                    "- contact_bios.bio should be 1-2 sentences tailored to the contact's title/department.\n"
+                    "- contact_bios[].interesting_facts MUST have at least 3 items (aim for 5-6). Populate from these sources IN ORDER:\n"
                     "  0) PDL person enrichment data (pdl_person_by_contact): skills, experience, education, summary, interests. These are HIGHLY reliable.\n"
                     "  1) REAL signals from contact_serper_by_topic: recent posts, talks, articles, LinkedIn activity (use actual URLs).\n"
                     "  2) Career signals: promotions, role changes, new company joins visible in snippets.\n"
@@ -1942,13 +1960,13 @@ async def conduct_research(request: ResearchRequest):
                     "  fact must be specific and outreach-ready (<=160 chars). BAD: 'Likely oversees reliability'. GOOD: 'Recently posted about scaling observability from 10 to 50 microservices'.\n"
                     "  source_url must be a real URL from the corpus. For role_insight signals, use source_url: '' and source_title: 'Role analysis'.\n"
                     "  NEVER produce vague facts like 'Likely cares about X'. Every fact must be specific enough to open a cold email with.\n"
-                    "- contact_bios[].outreach_angles: array of 2–4 short outreach angle strings, each <100 chars, connecting the contact's signals to the job seeker's value.\n"
-                    "- contact_bios[].urgency_score: integer 0–100 estimating how likely this contact is to respond NOW based on signals (hiring activity=high, recent posts=medium, no activity=low).\n"
+                    "- contact_bios[].outreach_angles: array of 2-4 short outreach angle strings, each <100 chars, connecting the contact's signals to the job seeker's value.\n"
+                    "- contact_bios[].urgency_score: integer 0-100 estimating how likely this contact is to respond NOW based on signals (hiring activity=high, recent posts=medium, no activity=low).\n"
                     "- contact_bios[].urgency_reason: 1 sentence explaining the urgency score.\n"
-                    "- hooks should be 4–8 punchy, concrete outreach angles (no fluff), grounded in the job pain_points / success_metrics if present.\n\n"
+                    "- hooks should be 4-8 punchy, concrete outreach angles (no fluff), grounded in the job pain_points / success_metrics if present.\n\n"
                     "Grounding rules for the Contact Background Report:\n"
                     "- If resume_extract or painpoint_matches are provided, use them to make the report SPECIFIC.\n"
-                    "  Example: cite 1 job pain point + 1 resume proof point + a recommended first 2–3 steps.\n"
+                    "  Example: cite 1 job pain point + 1 resume proof point + a recommended first 2-3 steps.\n"
                     "- Avoid generic coaching language. Make it a brief intelligence brief, not advice.\n\n"
                     "Contact Background Report (dynamic sections):\n"
                     "- Build a report titled 'Contact Background Report' for each contact, containing ~20 possible headings.\n"
@@ -2055,14 +2073,14 @@ async def conduct_research(request: ResearchRequest):
             news = entry.get("recent_news") or []
             if not isinstance(news, list):
                 news = []
-            theme = str(entry.get("theme") or "").strip()
-            culture_values = str(entry.get("company_culture_values") or "").strip()
-            market_position = str(entry.get("company_market_position") or "").strip()
-            product_launches = str(entry.get("company_product_launches") or "").strip()
-            leadership_changes = str(entry.get("company_leadership_changes") or "").strip()
-            other_hiring_signals = str(entry.get("company_other_hiring_signals") or "").strip()
-            recent_posts = str(entry.get("company_recent_posts") or "").strip()
-            publications = str(entry.get("company_publications") or "").strip()
+            theme = _strip_urls(str(entry.get("theme") or "").strip())
+            culture_values = _strip_urls(str(entry.get("company_culture_values") or "").strip())
+            market_position = _strip_urls(str(entry.get("company_market_position") or "").strip())
+            product_launches = _strip_urls(str(entry.get("company_product_launches") or "").strip())
+            leadership_changes = _strip_urls(str(entry.get("company_leadership_changes") or "").strip())
+            other_hiring_signals = _strip_urls(str(entry.get("company_other_hiring_signals") or "").strip())
+            recent_posts = _strip_urls(str(entry.get("company_recent_posts") or "").strip())
+            publications = _strip_urls(str(entry.get("company_publications") or "").strip())
             connections = entry.get("shared_connections") or []
             report_title = str(entry.get("background_report_title") or "Contact Background Report").strip() or "Contact Background Report"
             report_sections = entry.get("background_report_sections") or []
@@ -2184,7 +2202,7 @@ async def conduct_research(request: ResearchRequest):
                             label="Publications / case studies / reports (source-backed)",
                         )
                     if not other_hiring_signals:
-                        # "Other hiring signals" should come from the internet ("tea") — not the role description.
+                        # "Other hiring signals" should come from the internet ("tea")  - not the role description.
                         other_hiring_signals = _bullets_from_serper_hits(
                             (topics.get("signals") or topics.get("hiring") or topics.get("funding") or []),
                             max_items=8,
@@ -2385,7 +2403,7 @@ async def get_research_data(user_id: str):
             ],
             theme=(
                 "Theme: What the company cares about: Reference a plausible priority (customer experience, reliability, speed, cost) "
-                "and offer a 2–3 bullet mini-plan—without claiming a specific news event.\n"
+                "and offer a 2-3 bullet mini-plan -without claiming a specific news event.\n"
                 "- Start with a concrete customer outcome + one KPI\n"
                 "- Propose a low-risk first sprint (instrument → ship → measure)\n"
                 "- Close with a weekly reporting cadence"

--- a/backend/app/routers/deliverability_launch.py
+++ b/backend/app/routers/deliverability_launch.py
@@ -592,7 +592,7 @@ async def run_pre_flight_checks(request: CampaignLaunchRequest):
                 stub_json = {
                     "summary": "Deliverability looks acceptable; tighten the opener and reduce spam-trigger patterns.",
                     "copy_tweaks": [
-                        "Trim the first email to ~120 words and keep 0–1 links.",
+                        "Trim the first email to ~120 words and keep 0-1 links.",
                         "Remove promotional phrasing/excess punctuation; keep the CTA simple.",
                         "Lead with one specific pain point + one proof point.",
                     ],
@@ -689,7 +689,7 @@ async def check_deliverability(request: DeliverabilityCheckRequest):
             # Links
             link_count = len(re.findall(r"https?://", text, flags=re.I))
             if link_count >= 2:
-                warnings.append("Multiple links can increase spam risk (consider 0–1 link in step 1).")
+                warnings.append("Multiple links can increase spam risk (consider 0-1 link in step 1).")
 
             # Spam triggers
             for t in spam_triggers:
@@ -707,7 +707,7 @@ async def check_deliverability(request: DeliverabilityCheckRequest):
             words = re.findall(r"\w+", text)
             word_count = len(words)
             if word_count > 170:
-                warnings.append("Email is long; cold outreach performs better under ~120–150 words.")
+                warnings.append("Email is long; cold outreach performs better under ~120-150 words.")
             if word_count < 35:
                 warnings.append("Email may be too short; consider adding 1 concrete proof point.")
 
@@ -802,7 +802,7 @@ async def check_deliverability(request: DeliverabilityCheckRequest):
                             "- Avoid spammy wording (FREE/URGENT/CLICK HERE/etc), excessive punctuation, and ALL CAPS.\n"
                             "- Avoid canned openers like \"I hope this message finds you well\".\n"
                             "- Keep step 1 under ~120-150 words if possible.\n"
-                            "- Keep 0–1 links in step 1; if you include a link, introduce it naturally.\n"
+                            "- Keep 0-1 links in step 1; if you include a link, introduce it naturally.\n"
                             "- Preserve the user's intent and tone.\n\n"
                             "Return ONLY JSON with keys:\n"
                             "- summary: string\n"

--- a/backend/app/routers/demo.py
+++ b/backend/app/routers/demo.py
@@ -57,7 +57,7 @@ def seed_demo():
             "title": "Director of Product",
             "company": "Acme",
             "location": "Remote (US)",
-            "salary_text": "$220k–$260k + equity",
+            "salary_text": "$220k-$260k + equity",
             "jd_url": "https://example.com/acme/director-product",
             "jd_text": "Own product strategy for the core platform. Lead a team of PMs. Drive PLG and enterprise adoption across key verticals.",
             "tags": ["PLG", "Strategy", "Leadership"],
@@ -68,7 +68,7 @@ def seed_demo():
             "title": "Senior Product Manager, Activation",
             "company": "Acme",
             "location": "NYC (Hybrid)",
-            "salary_text": "$180k–$210k + bonus",
+            "salary_text": "$180k-$210k + bonus",
             "jd_url": "https://example.com/acme/spm-activation",
             "jd_text": "Increase activation, onboard enterprise customers, and run experiments across signup → first value.",
             "tags": ["Activation", "Experiments", "Onboarding"],
@@ -79,7 +79,7 @@ def seed_demo():
             "title": "Senior Product Manager, Data Platform",
             "company": "Acme",
             "location": "NYC (Hybrid)",
-            "salary_text": "$175k–$205k + equity",
+            "salary_text": "$175k-$205k + equity",
             "jd_url": "https://example.com/acme/spm-data",
             "jd_text": "Build self-serve data platform, governance, and metrics layer for analytics at scale.",
             "tags": ["Data Platform", "Governance", "Metrics"],
@@ -91,7 +91,7 @@ def seed_demo():
             "title": "Lead Product Manager, Analytics",
             "company": "Globex",
             "location": "SF Bay Area",
-            "salary_text": "$190k–$230k + equity",
+            "salary_text": "$190k-$230k + equity",
             "jd_url": "https://example.com/globex/lead-pm-analytics",
             "jd_text": "Own analytics roadmap; partner with data science and eng to ship insights and ML-powered workflows.",
             "tags": ["Analytics", "ML", "Insights"],
@@ -102,7 +102,7 @@ def seed_demo():
             "title": "Group PM, Platform",
             "company": "Globex",
             "location": "Remote (US)",
-            "salary_text": "$210k–$250k + equity",
+            "salary_text": "$210k-$250k + equity",
             "jd_url": "https://example.com/globex/gpm-platform",
             "jd_text": "Lead platform initiatives, APIs, and shared services; manage 3 PMs; align with GTM.",
             "tags": ["Platform", "APIs", "Leadership"],
@@ -113,7 +113,7 @@ def seed_demo():
             "title": "Product Manager, Billing",
             "company": "Globex",
             "location": "Remote (US)",
-            "salary_text": "$160k–$190k",
+            "salary_text": "$160k-$190k",
             "jd_url": "https://example.com/globex/pm-billing",
             "jd_text": "Own billing, entitlements, and invoicing. Partner with finance and GTM ops to reduce churn.",
             "tags": ["Billing", "Entitlements", "Payments"],
@@ -125,7 +125,7 @@ def seed_demo():
             "title": "Senior Product Manager, Growth",
             "company": "Initech",
             "location": "Austin, TX",
-            "salary_text": "$170k–$200k",
+            "salary_text": "$170k-$200k",
             "jd_url": "https://example.com/initech/spm-growth",
             "jd_text": "Drive PLG funnel, pricing/packaging experiments, and self-serve monetization.",
             "tags": ["Growth", "Pricing", "Monetization"],
@@ -136,7 +136,7 @@ def seed_demo():
             "title": "Director of Product, AI",
             "company": "Initech",
             "location": "Seattle, WA",
-            "salary_text": "$230k–$270k + equity",
+            "salary_text": "$230k-$270k + equity",
             "jd_url": "https://example.com/initech/dir-prod-ai",
             "jd_text": "Define AI product strategy, partner with research, and ship copilots and intelligent automation.",
             "tags": ["AI", "Copilots", "Automation"],
@@ -147,7 +147,7 @@ def seed_demo():
             "title": "Product Manager, Core",
             "company": "Initech",
             "location": "Remote (US)",
-            "salary_text": "$150k–$180k",
+            "salary_text": "$150k-$180k",
             "jd_url": "https://example.com/initech/pm-core",
             "jd_text": "Own core workflows, reliability, and user journeys across web and mobile.",
             "tags": ["Core", "Reliability", "Web/Mobile"],
@@ -158,7 +158,7 @@ def seed_demo():
             "title": "Head of Product",
             "company": "Initech",
             "location": "SF Bay Area",
-            "salary_text": "$260k–$320k + equity",
+            "salary_text": "$260k-$320k + equity",
             "jd_url": "https://example.com/initech/head-product",
             "jd_text": "Scale product org, hire PM leaders, and drive cross-functional roadmap alignment.",
             "tags": ["Leadership", "Hiring", "Strategy"],
@@ -170,7 +170,7 @@ def seed_demo():
             "title": "Technical Program Manager, Platform",
             "company": "Umbrella",
             "location": "Chicago, IL",
-            "salary_text": "$140k–$175k",
+            "salary_text": "$140k-$175k",
             "jd_url": "https://example.com/umbrella/tpm-platform",
             "jd_text": "Drive execution across platform teams; manage dependencies and risk; partner with PM/Eng leads.",
             "tags": ["TPM", "Execution", "Platform"],
@@ -182,7 +182,7 @@ def seed_demo():
             "title": "Senior Product Manager, Relevance",
             "company": "Hooli",
             "location": "Remote (US)",
-            "salary_text": "$180k–$220k",
+            "salary_text": "$180k-$220k",
             "jd_url": "https://example.com/hooli/spm-relevance",
             "jd_text": "Improve search and recommendation relevance; partner with ML to lift CTR and retention.",
             "tags": ["Search", "Relevance", "ML"],
@@ -194,7 +194,7 @@ def seed_demo():
             "title": "Product Manager, Supply Chain",
             "company": "Vandelay Industries",
             "location": "Remote (US)",
-            "salary_text": "$155k–$185k",
+            "salary_text": "$155k-$185k",
             "jd_url": "https://example.com/vandelay/pm-supply-chain",
             "jd_text": "Build tools for logistics, inventory optimization, and vendor performance analytics.",
             "tags": ["Supply Chain", "Logistics", "Analytics"],
@@ -206,7 +206,7 @@ def seed_demo():
             "title": "Product Manager, Security",
             "company": "WayneTech",
             "location": "Gotham, NJ",
-            "salary_text": "$165k–$195k",
+            "salary_text": "$165k-$195k",
             "jd_url": "https://example.com/waynetech/pm-security",
             "jd_text": "Ship security features (SSO, SCIM, audit logs, anomaly detection) for enterprise customers.",
             "tags": ["Security", "SSO", "Enterprise"],
@@ -218,7 +218,7 @@ def seed_demo():
             "title": "Product Manager, AI Ops",
             "company": "Stark Industries",
             "location": "Los Angeles, CA",
-            "salary_text": "$175k–$210k + equity",
+            "salary_text": "$175k-$210k + equity",
             "jd_url": "https://example.com/stark/pm-ai-ops",
             "jd_text": "Automate internal ops with AI agents; build oversight tooling; comply with governance.",
             "tags": ["AI", "Agents", "Ops"],
@@ -230,7 +230,7 @@ def seed_demo():
             "title": "Product Manager, Commerce",
             "company": "Wonka",
             "location": "Remote (US/EU)",
-            "salary_text": "$150k–$180k",
+            "salary_text": "$150k-$180k",
             "jd_url": "https://example.com/wonka/pm-commerce",
             "jd_text": "Own checkout, subscriptions, and promotions; lift conversion and lifetime value.",
             "tags": ["Checkout", "Subscriptions", "Growth"],
@@ -242,7 +242,7 @@ def seed_demo():
             "title": "Group PM, Distributed Systems",
             "company": "Pied Piper",
             "location": "Palo Alto, CA",
-            "salary_text": "$220k–$260k + equity",
+            "salary_text": "$220k-$260k + equity",
             "jd_url": "https://example.com/piedpiper/gpm-distributed",
             "jd_text": "Lead distributed storage and compression initiatives; manage PM team; define 2-year roadmap.",
             "tags": ["Distributed Systems", "Compression", "Leadership"],
@@ -254,7 +254,7 @@ def seed_demo():
             "title": "Product Manager, Mobile",
             "company": "Acme",
             "location": "Remote (US)",
-            "salary_text": "$150k–$180k",
+            "salary_text": "$150k-$180k",
             "jd_url": "https://example.com/acme/pm-mobile",
             "jd_text": "Own iOS/Android roadmap, performance, and engagement. Coordinate with design and growth.",
             "tags": ["Mobile", "iOS", "Android"],
@@ -265,7 +265,7 @@ def seed_demo():
             "title": "Product Manager, Integrations",
             "company": "Globex",
             "location": "Remote (Americas)",
-            "salary_text": "$155k–$185k",
+            "salary_text": "$155k-$185k",
             "jd_url": "https://example.com/globex/pm-integrations",
             "jd_text": "Ship integrations marketplace and SDKs; partner ecosystem growth; developer relations.",
             "tags": ["Integrations", "SDK", "Marketplace"],
@@ -276,7 +276,7 @@ def seed_demo():
             "title": "Product Manager, UX Research Ops",
             "company": "Initech",
             "location": "Remote (US)",
-            "salary_text": "$145k–$170k",
+            "salary_text": "$145k-$170k",
             "jd_url": "https://example.com/initech/pm-ux-research",
             "jd_text": "Build research repository, panel, and insight workflows; speed up discovery.",
             "tags": ["UX Research", "Repository", "Discovery"],
@@ -813,7 +813,7 @@ def seed_demo():
     outreach_presets = [
         {
             "id": "preset_short_email_pm",
-            "label": "Short Email – PM intro",
+            "label": "Short Email - PM intro",
             "mode": "email",
             "length": "short",
             "variables": {
@@ -831,7 +831,7 @@ def seed_demo():
         },
         {
             "id": "preset_li_note_growth",
-            "label": "LinkedIn Note – Growth angle",
+            "label": "LinkedIn Note - Growth angle",
             "mode": "linkedin",
             "length": "short",
             "variables": {
@@ -846,7 +846,7 @@ def seed_demo():
         },
         {
             "id": "preset_intro_mutual_ai",
-            "label": "Intro via Mutual – AI copilot",
+            "label": "Intro via Mutual - AI copilot",
             "mode": "intro-via-mutual",
             "length": "medium",
             "variables": {
@@ -862,7 +862,7 @@ def seed_demo():
         },
         {
             "id": "preset_email_long_billing",
-            "label": "Email – Long – Billing/Entitlements case",
+            "label": "Email - Long - Billing/Entitlements case",
             "mode": "email",
             "length": "long",
             "variables": {
@@ -880,7 +880,7 @@ def seed_demo():
         },
         {
             "id": "preset_email_medium_security",
-            "label": "Email – Medium – Security/SSO + Audit",
+            "label": "Email - Medium - Security/SSO + Audit",
             "mode": "email",
             "length": "medium",
             "variables": {
@@ -896,7 +896,7 @@ def seed_demo():
         },
         {
             "id": "preset_li_note_data_platform",
-            "label": "LinkedIn Note – Data Platform / Metrics Catalog",
+            "label": "LinkedIn Note - Data Platform / Metrics Catalog",
             "mode": "linkedin",
             "length": "short",
             "variables": {
@@ -911,7 +911,7 @@ def seed_demo():
         },
         {
             "id": "preset_email_medium_i18n",
-            "label": "Email – Medium – i18n/Regional Pricing",
+            "label": "Email - Medium - i18n/Regional Pricing",
             "mode": "email",
             "length": "medium",
             "variables": {
@@ -927,7 +927,7 @@ def seed_demo():
         },
         {
             "id": "preset_intro_mutual_platform_sdk",
-            "label": "Intro via Mutual – Platform SDKs",
+            "label": "Intro via Mutual - Platform SDKs",
             "mode": "intro-via-mutual",
             "length": "short",
             "variables": {
@@ -942,7 +942,7 @@ def seed_demo():
         },
         {
             "id": "preset_email_long_ai_ops",
-            "label": "Email – Long – AI Ops / Copilots",
+            "label": "Email - Long - AI Ops / Copilots",
             "mode": "email",
             "length": "long",
             "variables": {
@@ -958,7 +958,7 @@ def seed_demo():
         },
         {
             "id": "preset_li_note_growth_marketplace",
-            "label": "LinkedIn Note – Marketplace Growth",
+            "label": "LinkedIn Note - Marketplace Growth",
             "mode": "linkedin",
             "length": "short",
             "variables": {
@@ -1105,7 +1105,7 @@ def seed_demo():
             {"id": "apac.ops@umbrella.sg", "name": "Kenji Tanaka", "note": "APAC ops; schedule early PT slot", "assignee": "Oliver", "due_date": None},
         ],
         "Conversation": [
-            {"id": "cpo@wonka.com", "name": "Augustus Bloom", "note": "Positive reply; propose intro call (15–20m)", "assignee": "Oliver", "due_date": "2025-09-12"},
+            {"id": "cpo@wonka.com", "name": "Augustus Bloom", "note": "Positive reply; propose intro call (15-20m)", "assignee": "Oliver", "due_date": "2025-09-12"},
             {"id": "cto@stark.com", "name": "Morgan Stark", "note": "Replied with interest on AI Ops; share 1-pager", "assignee": "Oliver", "due_date": "2025-09-13"},
             {"id": "head.analytics@vandelay.com", "name": "Elaine Benes", "note": "Asked for metrics catalog examples", "assignee": "Oliver", "due_date": "2025-09-14"}
         ],
@@ -1156,7 +1156,7 @@ def seed_demo():
         {"type": "product_news", "detail": "Rolling out admin audit center; seeking examples of anomaly detection UX"},
     ])
     store.upsert_warm_angles("li:https://linkedin.com/in/leadubois", [
-        {"type": "alma_mater", "detail": "HEC Paris alum (2016) – Paris product meetup organizer"},
+        {"type": "alma_mater", "detail": "HEC Paris alum (2016) - Paris product meetup organizer"},
         {"type": "recent_post", "detail": "French-language note on i18n pitfalls and RTL testing"},
     ])
     store.upsert_warm_angles("domain:wonka.com", [
@@ -1171,7 +1171,7 @@ def seed_demo():
         {"type": "podcast_mention", "detail": "Mentioned on APAC Ops Leaders roundtable"},
     ])
     store.upsert_warm_angles("li:https://linkedin.com/in/elainebenes", [
-        {"type": "recent_post", "detail": "Metrics governance article – seeking examples of lineage UI"},
+        {"type": "recent_post", "detail": "Metrics governance article - seeking examples of lineage UI"},
         {"type": "mutual", "detail": "Connection to Jordan Lee (Data) and analytics guild lead"},
     ])
     store.upsert_warm_angles("domain:vandelay.com", [
@@ -1653,13 +1653,13 @@ def seed_demo():
         {"id": "unsubscribe:sam@globex.com", "reason": "Unsubscribe requested"},
         {"id": "block:enterprise@acme.com", "reason": "Do-not-contact (enterprise policy)"},
         {"id": "gdpr:eu.pm@wonka.eu", "reason": "GDPR delete request"},
-        {"id": "domain:*@examplebank.com", "reason": "Financial institution – restrict unsolicited outreach"},
+        {"id": "domain:*@examplebank.com", "reason": "Financial institution - restrict unsolicited outreach"},
         {"id": "role:*legal*@*", "reason": "Exclude legal/compliance roles from sequences"},
         {"id": "region:DE", "reason": "German recipients opted out of marketing"},
-        {"id": "unsubscribe:cto@stark.com", "reason": "Unsubscribe – internal policy"},
-        {"id": "bounce:recruiting@globex.com", "reason": "Hard bounce – suppress"},
-        {"id": "complaint:ops@umbrella.sg", "reason": "Complaint received – add to DNC"},
-        {"id": "privacy:head.analytics@vandelay.com", "reason": "Privacy request – no further contact"}
+        {"id": "unsubscribe:cto@stark.com", "reason": "Unsubscribe - internal policy"},
+        {"id": "bounce:recruiting@globex.com", "reason": "Hard bounce - suppress"},
+        {"id": "complaint:ops@umbrella.sg", "reason": "Complaint received - add to DNC"},
+        {"id": "privacy:head.analytics@vandelay.com", "reason": "Privacy request - no further contact"}
     ]
     store.set_dnc(dnc)
     # Seed Webhook-like events into Audit + reflect on messages
@@ -1787,7 +1787,7 @@ def seed_demo():
         scored.sort(key=lambda x: x["score"], reverse=True)
         for rank, m in enumerate(scored[:6], start=1):
             m["rank"] = rank
-            m["summary"] = f"{m['candidate_id']} vs {m['company']} – {m['title']}"
+            m["summary"] = f"{m['candidate_id']} vs {m['company']} - {m['title']}"
             m["created_at"] = "2025-09-10T10:00:00Z"
             seeded_matches.append(m)
     store.set_matches(seeded_matches)
@@ -1883,7 +1883,7 @@ def seed_demo():
     store.set_portfolio_assets("cand_alex_pm", [
         {"id": "pa_alex_1", "type": "doc", "title": "PLG Playbook", "url": "https://drive.example.com/alex-plg", "tags": ["PLG", "Activation"], "thumbnail_url": "https://img.example.com/plg.png", "preview_text": "Activation system design...", "source": "doc", "relevance_score": 0.92, "created_at": "2024-11-12"},
         {"id": "pa_alex_2", "type": "deck", "title": "Onboarding Redesign", "url": "https://drive.example.com/alex-onboarding", "tags": ["Onboarding"], "thumbnail_url": "https://img.example.com/onboarding.png", "preview_text": "Guided flows and value moments...", "source": "deck", "relevance_score": 0.88, "created_at": "2025-02-20"},
-        {"id": "pa_alex_3", "type": "link", "title": "Case Study – Conversion", "url": "https://portfolio.example.com/case-conv", "tags": ["CaseStudy"], "thumbnail_url": "https://img.example.com/case.png", "preview_text": "Trial→paid uplift...", "source": "link", "relevance_score": 0.81, "created_at": "2025-05-02"},
+        {"id": "pa_alex_3", "type": "link", "title": "Case Study - Conversion", "url": "https://portfolio.example.com/case-conv", "tags": ["CaseStudy"], "thumbnail_url": "https://img.example.com/case.png", "preview_text": "Trial→paid uplift...", "source": "link", "relevance_score": 0.81, "created_at": "2025-05-02"},
     ])
     store.set_portfolio_assets("cand_sam_ai", [
         {"id": "pa_sam_1", "type": "deck", "title": "AI Copilot Overview", "url": "https://drive.example.com/ai-copilot", "tags": ["AI", "Copilot"], "thumbnail_url": "https://img.example.com/copilot.png", "preview_text": "Guardrails and evaluation...", "source": "deck", "relevance_score": 0.9, "created_at": "2025-01-10"},
@@ -1891,9 +1891,9 @@ def seed_demo():
     ])
     # Seed Instantly campaign objects (mock)
     campaigns = [
-        {"id": "cmp_001", "name": "Demo – PM Intro", "variant": "preset_short_email_pm", "list_size": 50, "status": "active", "created_at": "2025-09-09T09:00:00Z"},
-        {"id": "cmp_002", "name": "Demo – AI Ops", "variant": "preset_email_long_ai_ops", "list_size": 40, "status": "paused", "created_at": "2025-09-09T11:30:00Z"},
-        {"id": "cmp_003", "name": "Demo – Billing", "variant": "preset_email_long_billing", "list_size": 35, "status": "draft", "created_at": "2025-09-10T08:45:00Z"},
+        {"id": "cmp_001", "name": "Demo - PM Intro", "variant": "preset_short_email_pm", "list_size": 50, "status": "active", "created_at": "2025-09-09T09:00:00Z"},
+        {"id": "cmp_002", "name": "Demo - AI Ops", "variant": "preset_email_long_ai_ops", "list_size": 40, "status": "paused", "created_at": "2025-09-09T11:30:00Z"},
+        {"id": "cmp_003", "name": "Demo - Billing", "variant": "preset_email_long_billing", "list_size": 35, "status": "draft", "created_at": "2025-09-10T08:45:00Z"},
     ]
     for c in campaigns:
         store.add_campaign(c)

--- a/backend/app/routers/find_contact.py
+++ b/backend/app/routers/find_contact.py
@@ -552,28 +552,27 @@ def _painpoint_phrase(pain: str) -> str:
 def _deterministic_improve_linkedin_note(req: ImproveLinkedInNoteRequest) -> str:
     name = (req.contact_name or "").strip()
     first = (name.split()[0] if name else "").strip() or "there"
-    company = (req.contact_company or "").strip() or "your team"
-    title = (req.contact_title or "").strip()
+    company = (req.contact_company or "").strip()
     sol = (req.solution or "").strip()
-    metric = (req.metric or "").strip()
+    painpoint = (req.painpoint or "").strip()
 
-    # Keep it warm/casual but professional; no role/job language.
     bits: List[str] = [f"Hi {first},"]
-    bits.append("I reviewed your profile and wanted to connect.")
-    if title and company:
-        bits.append(f"Your work as {title} at {company} stood out.")
+
+    # Bridge: shared industry/community framing, not title-targeting.
+    if painpoint and company:
+        bits.append(f"I enjoy connecting with leaders in {painpoint.lower().split(',')[0].strip()}, always good to expand the network with people at firms like {company}.")
     elif company:
-        bits.append(f"Your work at {company} stood out.")
-    if sol and len(sol) <= 72:
-        if metric and len(metric) <= 42:
-            bits.append(f"A bit about me: {sol}, {metric}.")
-        else:
-            bits.append(f"A bit about me: {sol}.")
-    elif metric and len(metric) <= 64:
-        bits.append(f"A bit about me: {metric}.")
+        bits.append(f"I reviewed your profile and wanted to connect - always good to expand the network with people at {company}.")
+    elif painpoint:
+        bits.append(f"I enjoy connecting with leaders in {painpoint.lower().split(',')[0].strip()}, always good to expand the network.")
     else:
-        bits.append("A bit about me: I enjoy building practical, measurable solutions.")
-    bits.append("Open to connect?")
+        bits.append("I reviewed your profile and wanted to connect.")
+
+    # Value prop: what sender posts about / works on.
+    if sol and len(sol) <= 72:
+        bits.append(f"I post about {sol.rstrip('.')}.")
+
+    bits.append("Let's connect.")
     return " ".join([b.strip() for b in bits if b.strip()])
 
 
@@ -1205,27 +1204,33 @@ async def improve_linkedin_note(request: ImproveLinkedInNoteRequest) -> ImproveL
                 "content": (
                     "You rewrite LinkedIn connection request notes.\n\n"
                     "Goal:\n"
-                    "- Make the message sound human, casual, warm, and personal, while still professional for a first contact.\n\n"
+                    "- Create a warm, community-building connection request that frames the sender and receiver as peers in the same space.\n\n"
                     "Hard constraints:\n"
                     "- Output MUST be valid JSON ONLY (no markdown) with key: note\n"
                     "- note MUST be a single paragraph (no bullets)\n"
                     "- note MUST be <= limit characters\n"
-                    "- Do NOT use em dashes or en dashes (— or –). Use commas/periods/parentheses or simple hyphens.\n"
-                    "- Do NOT include clichés like 'I hope you're doing well'.\n"
+                    "- Do NOT use em dashes or en dashes. Use commas/periods/parentheses or simple hyphens.\n"
+                    "- Do NOT include cliches like 'I hope you're doing well'.\n"
                     "- Do NOT mention that you are an AI.\n"
-                    "- Do NOT fabricate facts.\n\n"
+                    "- Do NOT fabricate facts.\n"
                     "- Do NOT mention applying for a role or job.\n"
-                    "- Do NOT mention 'job title', 'opening', 'application', or 'hiring process'.\n\n"
+                    "- Do NOT mention 'job title', 'opening', 'application', or 'hiring process'.\n"
+                    "- Do NOT mention the contact's specific job title. Saying 'Chief Executive Officer' or 'VP of Engineering' sounds like targeting.\n"
+                    "- Do NOT lead with the sender's accomplishments or metrics. That sounds like a pitch.\n\n"
                     "Rewrite rules:\n"
                     "- You may rewrite from scratch. Do NOT preserve awkward grammar from the input note.\n"
-                    "- Use a clean opening like: 'Hi <first>, I reviewed your profile and wanted to connect.'\n"
-                    "- Include 2-3 short details total across:\n"
-                    "  (a) one profile-based mention about the contact, and\n"
-                    "  (b) one or two short 'about me' points from provided solution/metric context when available.\n"
-                    "- Keep it about the person and connection intent, not a job process.\n\n"
+                    "- Build a BRIDGE between sender and receiver: shared industry, shared interests, or value the sender brings to the network.\n"
+                    "- Frame the connection as community/network building, NOT transactional.\n"
+                    "- If painpoint/industry context is provided, use it to frame shared space (e.g., 'I enjoy connecting with leaders in [industry]').\n"
+                    "- If solution context is provided, frame it as what the sender posts about or works on, NOT as an accomplishment.\n"
+                    "- Good patterns:\n"
+                    "  'I enjoy connecting with leaders in [industry], always good to expand the network with people at firms like [company].'\n"
+                    "  'I work with [industry] leaders across [region], would love to add you to my network.'\n"
+                    "  'I post about [topics]. Let's connect.'\n"
+                    "- End with a soft close like 'Let's connect.' or 'Would love to add you to my network.'\n\n"
                     "Style:\n"
-                    "- Keep it simple: greeting + profile tie-in + 1-2 about-me details + soft close.\n"
-                    "- Use 1-2 short sentences if possible.\n"
+                    "- 2-3 short sentences max. Warm and casual but professional.\n"
+                    "- The note should feel like a peer reaching out, not someone asking for something.\n"
                 ),
             },
             {"role": "user", "content": json.dumps(ctx)},

--- a/backend/app/routers/find_contact.py
+++ b/backend/app/routers/find_contact.py
@@ -214,6 +214,34 @@ _NAME_STOPWORDS = {
     "privacy",
     "terms",
     "google",
+    "draw",
+    "design",
+    "board",
+    "canvas",
+    "studio",
+    "cloud",
+    "platform",
+    "tools",
+    "features",
+    "solutions",
+    "services",
+    "enterprise",
+    "connect",
+    "share",
+    "create",
+    "build",
+    "explore",
+    "discover",
+    "learn",
+    "start",
+    "pricing",
+    "support",
+    "blog",
+    "docs",
+    "community",
+    "resources",
+    "login",
+    "signup",
 }
 
 
@@ -245,17 +273,39 @@ def _looks_like_title(s: str) -> bool:
 
 def _infer_level(title: str) -> str:
     low = (title or "").lower()
-    if any(k in low for k in ["chief", "ceo", "cto", "cfo", "coo"]):
-        return "C-Level"
-    if "vp" in low or "vice president" in low:
+    if any(k in low for k in ["chief", "ceo", "cto", "cfo", "coo", "founder", "president"]):
+        return "C-Suite"
+    if "vp" in low or "vice president" in low or "svp" in low:
         return "VP"
-    if "director" in low:
+    if "director" in low or "head" in low:
         return "Director"
-    if "head" in low:
-        return "Head"
     if "manager" in low:
         return "Manager"
-    return "Lead"
+    if any(k in low for k in ["senior", "staff", "principal", "lead", "sr."]):
+        return "Senior"
+    return "Senior"
+
+
+def _matches_seniority_filter(level: str, seniority_csv: str) -> bool:
+    if not seniority_csv:
+        return True
+    allowed = {s.strip().lower() for s in seniority_csv.split(",") if s.strip()}
+    if not allowed:
+        return True
+    lvl = (level or "").strip().lower()
+    if lvl in allowed:
+        return True
+    aliases = {
+        "c-suite": {"c-level", "c-suite", "executive"},
+        "c-level": {"c-suite", "c-level", "executive"},
+        "vp": {"vp", "vice president"},
+        "director": {"director", "head"},
+        "head": {"director", "head"},
+        "manager": {"manager"},
+        "senior": {"senior", "lead", "principal", "staff"},
+        "lead": {"senior", "lead"},
+    }
+    return bool(allowed & aliases.get(lvl, set()))
 
 
 def _infer_department(title: str) -> str:
@@ -394,11 +444,10 @@ class ContactSearchRequest(BaseModel):
     query: str
     company: Optional[str] = None
     role: Optional[str] = None
-    # Optional: explicit title filters (Apollo/SalesNav-style). When provided, we try to return
-    # decision makers whose titles match ANY of these options.
     title_filters: Optional[List[str]] = None
     level: Optional[str] = None
-    # Context from upstream steps so we can pick ONLY relevant decision makers for the role being applied for.
+    seniority: Optional[str] = None
+    location: Optional[str] = None
     target_job_title: Optional[str] = None
     candidate_title: Optional[str] = None
     user_mode: Optional[str] = None
@@ -957,8 +1006,14 @@ async def search_contacts(request: ContactSearchRequest):
             except Exception:
                 logger.exception("LLM contact relevance audit failed (non-blocking)")
 
+        # Apply seniority filter from UI (if provided).
+        seniority_csv = (request.seniority or "").strip()
+        if seniority_csv and contacts:
+            filtered = [c for c in contacts if _matches_seniority_filter(c.level, seniority_csv)]
+            if filtered:
+                contacts = filtered
+
         # Hard cap for UI sanity: avoid overwhelming lists.
-        # (Users can widen title filters to change *which* contacts show, not how many.)
         try:
             contacts = (contacts or [])[:24]
         except Exception:

--- a/backend/app/routers/find_contact.py
+++ b/backend/app/routers/find_contact.py
@@ -969,10 +969,10 @@ async def search_contacts(request: ContactSearchRequest):
             "talking_points_by_contact": {},
             "opener_suggestions": [
                 "Quick question on your priorities for the role",
-                "Noticed a theme in the job posting \u2014 here\u2019s a concrete idea",
+                "Noticed a theme in the job posting - here's a concrete idea",
             ],
             "questions_to_ask": [
-                "What\u2019s the most urgent outcome you need in the next 90 days?",
+                "What's the most urgent outcome you need in the next 90 days?",
                 "Where is the team currently feeling the most pain (quality, speed, cost)?",
             ],
         }
@@ -1170,7 +1170,7 @@ async def improve_linkedin_note(request: ImproveLinkedInNoteRequest) -> ImproveL
                     "- Keep it about the person and connection intent, not a job process.\n\n"
                     "Style:\n"
                     "- Keep it simple: greeting + profile tie-in + 1-2 about-me details + soft close.\n"
-                    "- Use 1–2 short sentences if possible.\n"
+                    "- Use 1-2 short sentences if possible.\n"
                 ),
             },
             {"role": "user", "content": json.dumps(ctx)},

--- a/backend/app/routers/find_contact.py
+++ b/backend/app/routers/find_contact.py
@@ -389,7 +389,7 @@ def _extract_contacts_from_text(text: str, company: str, domain: str, source_url
         return s
 
     uniq = sorted(uniq, key=lambda t: score(t[1]), reverse=True)
-    uniq = [p for p in uniq if score(p[1]) > -1000][:8]
+    uniq = [p for p in uniq if score(p[1]) > -1000][:15]
 
     contacts: List[Contact] = []
     for nm, title in uniq:
@@ -716,7 +716,7 @@ async def search_contacts(request: ContactSearchRequest):
                 talent_dm = [p for _, p in scored if _is_recruiting(p.title)]
                 others = [p for _, p in scored if p not in fn_dm and p not in talent_dm and _is_relevant_decision_maker_for_job(p.title, job_fn)]
 
-                desired = 24
+                desired = 50
 
                 relevant_pool = [p for _, p in scored if _is_relevant_decision_maker_for_job(p.title, job_fn)]
 
@@ -734,9 +734,9 @@ async def search_contacts(request: ContactSearchRequest):
                 else:
                     if relevant_pool:
                         picked: List[Any] = []
-                        for p in fn_dm[:6]:
+                        for p in fn_dm[:12]:
                             picked.append(p)
-                        for p in talent_dm[:5]:
+                        for p in talent_dm[:8]:
                             if p not in picked:
                                 picked.append(p)
                         for p in others:
@@ -823,7 +823,7 @@ async def search_contacts(request: ContactSearchRequest):
                 logger.info("Web scrape: no working leadership/team page found for domain='%s'", domain)
 
         # 3) Try OpenAI to identify public personas (supplements PDL + web scraping)
-        if len(contacts) + len(pdl_contacts) < 8 and settings.openai_api_key and _budget_ok(10.0):
+        if len(contacts) + len(pdl_contacts) < 15 and settings.openai_api_key and _budget_ok(10.0):
             try:
                 client = get_openai_client()
                 # Ask GPT to identify likely decision makers based on its training data (broad knowledge).
@@ -832,7 +832,7 @@ async def search_contacts(request: ContactSearchRequest):
                 filters = [str(x).strip() for x in (request.title_filters or []) if str(x).strip()]
                 prompt = "".join(
                     [
-                        f"Identify 6-12 REAL people who work at '{company}' in leadership, management, recruiting, or executive roles.\n\n",
+                        f"Identify 12-20 REAL people who work at '{company}' in leadership, management, recruiting, or executive roles.\n\n",
                         f"Context: the user is looking for people who might influence hiring for a '{target or 'this role'}' position.\n\n",
                         "Include:\n",
                         "- VP/Director/Head/Manager of Engineering, Product, Design, HR, Talent, etc.\n",
@@ -1014,7 +1014,7 @@ async def search_contacts(request: ContactSearchRequest):
 
         # Hard cap for UI sanity: avoid overwhelming lists.
         try:
-            contacts = (contacts or [])[:24]
+            contacts = (contacts or [])[:30]
         except Exception:
             pass
 

--- a/backend/app/routers/gap_analysis.py
+++ b/backend/app/routers/gap_analysis.py
@@ -455,7 +455,7 @@ def _deterministic_personality_gaps(
                     gap="Role is stakeholder-heavy; your style may be more deep-focus/independent.",
                     severity="medium",
                     evidence=["Personality: focus-charged (energy axis)", "Job text mentions stakeholders/cross-functional work"],
-                    how_to_close="Show 1–2 examples of driving alignment with stakeholders (cadence, docs, decision records) without losing execution speed.",
+                    how_to_close="Show 1-2 examples of driving alignment with stakeholders (cadence, docs, decision records) without losing execution speed.",
                 )
             )
 

--- a/backend/app/routers/job_preferences.py
+++ b/backend/app/routers/job_preferences.py
@@ -457,7 +457,7 @@ def _deterministic_recommendations(p: JobPreferences) -> List[JobRecommendation]
             source="indeed",
             url=f"https://www.indeed.com/jobs?q={q_indeed}&l={lc}",
             link_type="job_board_search",
-            rationale="Broad results (Indeed works best with 1 main role + 0–1 skill keywords).",
+            rationale="Broad results (Indeed works best with 1 main role + 0-1 skill keywords).",
             score=70,
             created_at=created_at,
         )
@@ -874,8 +874,8 @@ async def save_job_preferences(preferences: JobPreferences):
             "suggested_skills": ["Product analytics", "Experiment design", "SQL", "Stakeholder management"],
             "suggested_role_categories": preferences.role_categories[:1],
             "notes": [
-                "Keep skills to 8–12 high-signal items; remove near-duplicates.",
-                "Add 1–2 domain skills that match your target industry (e.g., onboarding/activation).",
+                "Keep skills to 8-12 high-signal items; remove near-duplicates.",
+                "Add 1-2 domain skills that match your target industry (e.g., onboarding/activation).",
             ],
         }
         raw = client.run_chat_completion(messages, temperature=0.1, max_tokens=450, stub_json=stub_json)

--- a/backend/app/routers/lead_qual.py
+++ b/backend/app/routers/lead_qual.py
@@ -165,7 +165,7 @@ async def run_pipeline(payload: PipelineRunRequest) -> Dict[str, Any]:
         results.append({
             "domain": d,
             "top_prospect": {
-                "name": preview.get("name") or "—",
+                "name": preview.get("name") or "-",
                 "title": preview.get("title") or payload.role_query,
                 "linkedin_url": preview.get("linkedin_url"),
                 "decision": decision,

--- a/backend/app/routers/offer_creation.py
+++ b/backend/app/routers/offer_creation.py
@@ -72,12 +72,13 @@ class ComposeOfferSnippetResponse(BaseModel):
 
 
 class GenerateCtaRequest(BaseModel):
-    cta_type: str  # "hard" or "soft"
+    cta_type: str  # "hard", "soft", or "personalized"
     current_cta: str = ""
     role_title: Optional[str] = None
     role_company: Optional[str] = None
     skills: List[str] = []
     one_liner: str = ""
+    pain_points: List[str] = []
 
 
 class GenerateCtaResponse(BaseModel):
@@ -251,7 +252,13 @@ async def compose_offer_snippet(payload: ComposeOfferSnippetRequest):
 async def generate_cta(payload: GenerateCtaRequest):
     import random
 
-    pool = _HARD_CTA_POOL if payload.cta_type == "hard" else _SOFT_CTA_POOL
+    is_personalized = payload.cta_type == "personalized"
+    is_hard = payload.cta_type == "hard"
+
+    if is_personalized:
+        pool = _HARD_CTA_POOL
+    else:
+        pool = _HARD_CTA_POOL if is_hard else _SOFT_CTA_POOL
     current = (payload.current_cta or "").strip().lower().rstrip("?.")
 
     candidates = [c for c in pool if c.strip().lower().rstrip("?.") != current]
@@ -259,12 +266,52 @@ async def generate_cta(payload: GenerateCtaRequest):
 
     client = get_openai_client()
     if not client.should_use_real_llm:
+        if is_personalized:
+            pain = (payload.pain_points[0] if payload.pain_points else "").strip().lower()
+            if pain and payload.role_company:
+                deterministic_pick = f"If {pain} is a priority at {payload.role_company}, I would love to share how I have tackled a similar challenge."
+            elif pain:
+                deterministic_pick = f"If {pain} is on your radar this quarter, I would love to compare notes."
+            else:
+                deterministic_pick = "If this aligns with your priorities, I would love to share how I have tackled a similar challenge."
         return GenerateCtaResponse(success=True, cta=deterministic_pick, used_llm=False)
 
     try:
-        is_hard = payload.cta_type == "hard"
         skills_str = ", ".join((payload.skills or [])[:6]) or "their professional skills"
         role_str = payload.role_title or "the target role"
+        company_str = payload.role_company or "the target company"
+        pain_str = "; ".join((payload.pain_points or [])[:3])
+
+        if is_personalized:
+            type_block = (
+                "TYPE: Personalized CTA\n"
+                "A personalized CTA ties the sender's expertise directly to the recipient's specific challenges.\n"
+                "It references the role's pain points or company priorities and frames the sender's value around them.\n"
+                "It can be a question or an invitation - the key is it feels custom-written for THIS role.\n\n"
+                "Examples:\n"
+                "- 'If enhancing fraud prevention aligns with your priorities, I invite you to watch the included video for a brief overview.'\n"
+                "- 'Is this preemptive approach to securing remote workforce transactions something you are considering this quarter or next?'\n"
+                "- 'If scaling your analytics pipeline is a priority this quarter, I would love to share how I tackled a similar challenge.'\n\n"
+                f"Role pain points: {pain_str or 'not specified'}\n"
+                f"Company: {company_str}\n"
+            )
+            char_limit = "under 140 characters"
+        elif is_hard:
+            type_block = (
+                "TYPE: Hard CTA\n"
+                "A hard CTA asks for a specific commitment: a call, a meeting, a time slot.\n"
+                "It should feel confident but not pushy. Include a time frame or specific action.\n"
+                "Examples: 'Open to a 10-minute chat this week?', 'Could we do a quick call Tuesday or Thursday?'\n\n"
+            )
+            char_limit = "under 100 characters"
+        else:
+            type_block = (
+                "TYPE: Soft CTA\n"
+                "A soft CTA is low-friction: an easy yes/no, a gentle nudge, permission to follow up.\n"
+                "It should feel zero-pressure. The recipient can say no without awkwardness.\n"
+                "Examples: 'Worth exploring, or totally not a priority right now?', 'Curious if this resonates - no worries either way.'\n\n"
+            )
+            char_limit = "under 100 characters"
 
         messages = [
             {
@@ -272,21 +319,11 @@ async def generate_cta(payload: GenerateCtaRequest):
                 "content": (
                     "You generate a single call-to-action sentence for a job seeker's outreach email.\n"
                     "Return ONLY JSON: {\"cta\": string}\n\n"
-                    + (
-                        "TYPE: Hard CTA\n"
-                        "A hard CTA asks for a specific commitment: a call, a meeting, a time slot.\n"
-                        "It should feel confident but not pushy. Include a time frame or specific action.\n"
-                        "Examples: 'Open to a 10-minute chat this week?', 'Could we do a quick call Tuesday or Thursday?'\n\n"
-                        if is_hard else
-                        "TYPE: Soft CTA\n"
-                        "A soft CTA is low-friction: an easy yes/no, a gentle nudge, permission to follow up.\n"
-                        "It should feel zero-pressure. The recipient can say no without awkwardness.\n"
-                        "Examples: 'Worth exploring, or totally not a priority right now?', 'Curious if this resonates - no worries either way.'\n\n"
-                    )
+                    + type_block
                     + f"Context: the sender's skills include {skills_str}. Target role: {role_str}.\n"
                     + f"The sender's one-liner: {(payload.one_liner or '').strip()[:120]}\n\n"
                     "Rules:\n"
-                    "- One sentence only, under 100 characters.\n"
+                    f"- One or two sentences, {char_limit}.\n"
                     "- Do NOT use em dashes or en dashes.\n"
                     "- Do NOT mention applying for a job or the hiring process.\n"
                     "- Do NOT repeat or closely paraphrase the current CTA.\n"
@@ -296,8 +333,9 @@ async def generate_cta(payload: GenerateCtaRequest):
             },
         ]
 
+        max_tok = 80 if is_personalized else 60
         raw = client.run_chat_completion(
-            messages, temperature=0.8, max_tokens=60,
+            messages, temperature=0.8, max_tokens=max_tok,
             stub_json={"cta": deterministic_pick},
         )
         choices = raw.get("choices") or []
@@ -306,7 +344,8 @@ async def generate_cta(payload: GenerateCtaRequest):
         parsed = extract_json_from_text(content_str) or {}
         cta = str(parsed.get("cta") or "").strip()
         cta = re.sub(r"[—–]", "-", cta)
-        if len(cta) < 10 or len(cta) > 120:
+        max_len = 180 if is_personalized else 120
+        if len(cta) < 10 or len(cta) > max_len:
             cta = deterministic_pick
         return GenerateCtaResponse(success=True, cta=cta, used_llm=True)
     except Exception:

--- a/backend/app/routers/offer_creation.py
+++ b/backend/app/routers/offer_creation.py
@@ -234,7 +234,7 @@ async def create_offer(request: OfferCreationRequest):
                     f"I noticed the challenges around {pain}. "
                     f"I’ve done similar work, for example: {sol}. "
                     f"Impact: {metric_phrase}. "
-                    "If it’s useful, I can share a 2–3 bullet plan tailored to this role."
+                    "If it’s useful, I can share a 2-3 bullet plan tailored to this role."
                 )
             else:
                 raw_label = base_match.get("painpoint_1", "Your Role")

--- a/backend/app/routers/offer_creation.py
+++ b/backend/app/routers/offer_creation.py
@@ -71,6 +71,48 @@ class ComposeOfferSnippetResponse(BaseModel):
     used_llm: bool = False
 
 
+class GenerateCtaRequest(BaseModel):
+    cta_type: str  # "hard" or "soft"
+    current_cta: str = ""
+    role_title: Optional[str] = None
+    role_company: Optional[str] = None
+    skills: List[str] = []
+    one_liner: str = ""
+
+
+class GenerateCtaResponse(BaseModel):
+    success: bool
+    cta: str
+    used_llm: bool = False
+
+
+_HARD_CTA_POOL = [
+    "Open to a 10-minute chat this week?",
+    "Could we do a quick call Tuesday or Thursday?",
+    "Happy to walk through specifics - does 15 minutes work this week?",
+    "Would a brief call be useful? I can share concrete examples.",
+    "Can I show you what this looks like in practice? 15 minutes, any day that works.",
+    "If this sounds relevant, I'd love 10 minutes to compare notes.",
+    "Would it help to see a short walkthrough? Happy to set something up.",
+    "I have a few ideas that might be useful - open to a quick call?",
+    "Interested in seeing how this could work for your team? Let's find 15 minutes.",
+    "Can we grab a brief call? I'll keep it focused and concise.",
+]
+
+_SOFT_CTA_POOL = [
+    "Worth exploring, or totally not a priority right now?",
+    "Does this sound relevant, or is the timing off?",
+    "Curious if this resonates - no worries either way.",
+    "Is this on your radar, or not the right moment?",
+    "Figured it was worth a mention - happy to share more if useful.",
+    "If this isn't a fit, no worries at all - just wanted to flag it.",
+    "Sound interesting, or should I check back another time?",
+    "If the timing is right, I'd love to chat - if not, totally understand.",
+    "Would love your take on whether this is worth a conversation.",
+    "Let me know if this is worth exploring - either way, appreciate your time.",
+]
+
+
 def _build_rule_based_snippet(payload: ComposeOfferSnippetRequest) -> str:
     one = re.sub(r"\s+", " ", str(payload.one_liner or "")).strip()[:220]
     proofs = [re.sub(r"\s+", " ", str(x or "")).strip()[:160] for x in (payload.proof_points or []) if str(x or "").strip()]
@@ -203,6 +245,73 @@ async def compose_offer_snippet(payload: ComposeOfferSnippetRequest):
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to compose offer snippet: {str(e)}")
+
+
+@router.post("/generate-cta", response_model=GenerateCtaResponse)
+async def generate_cta(payload: GenerateCtaRequest):
+    import random
+
+    pool = _HARD_CTA_POOL if payload.cta_type == "hard" else _SOFT_CTA_POOL
+    current = (payload.current_cta or "").strip().lower().rstrip("?.")
+
+    candidates = [c for c in pool if c.strip().lower().rstrip("?.") != current]
+    deterministic_pick = random.choice(candidates) if candidates else pool[0]
+
+    client = get_openai_client()
+    if not client.should_use_real_llm:
+        return GenerateCtaResponse(success=True, cta=deterministic_pick, used_llm=False)
+
+    try:
+        is_hard = payload.cta_type == "hard"
+        skills_str = ", ".join((payload.skills or [])[:6]) or "their professional skills"
+        role_str = payload.role_title or "the target role"
+
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You generate a single call-to-action sentence for a job seeker's outreach email.\n"
+                    "Return ONLY JSON: {\"cta\": string}\n\n"
+                    + (
+                        "TYPE: Hard CTA\n"
+                        "A hard CTA asks for a specific commitment: a call, a meeting, a time slot.\n"
+                        "It should feel confident but not pushy. Include a time frame or specific action.\n"
+                        "Examples: 'Open to a 10-minute chat this week?', 'Could we do a quick call Tuesday or Thursday?'\n\n"
+                        if is_hard else
+                        "TYPE: Soft CTA\n"
+                        "A soft CTA is low-friction: an easy yes/no, a gentle nudge, permission to follow up.\n"
+                        "It should feel zero-pressure. The recipient can say no without awkwardness.\n"
+                        "Examples: 'Worth exploring, or totally not a priority right now?', 'Curious if this resonates - no worries either way.'\n\n"
+                    )
+                    + f"Context: the sender's skills include {skills_str}. Target role: {role_str}.\n"
+                    + f"The sender's one-liner: {(payload.one_liner or '').strip()[:120]}\n\n"
+                    "Rules:\n"
+                    "- One sentence only, under 100 characters.\n"
+                    "- Do NOT use em dashes or en dashes.\n"
+                    "- Do NOT mention applying for a job or the hiring process.\n"
+                    "- Do NOT repeat or closely paraphrase the current CTA.\n"
+                    f"- Current CTA to avoid: \"{payload.current_cta}\"\n"
+                    "- Sound human and conversational, not corporate.\n"
+                ),
+            },
+        ]
+
+        raw = client.run_chat_completion(
+            messages, temperature=0.8, max_tokens=60,
+            stub_json={"cta": deterministic_pick},
+        )
+        choices = raw.get("choices") or []
+        msg = (choices[0].get("message") if choices else {}) or {}
+        content_str = str(msg.get("content") or "")
+        parsed = extract_json_from_text(content_str) or {}
+        cta = str(parsed.get("cta") or "").strip()
+        cta = re.sub(r"[—–]", "-", cta)
+        if len(cta) < 10 or len(cta) > 120:
+            cta = deterministic_pick
+        return GenerateCtaResponse(success=True, cta=cta, used_llm=True)
+    except Exception:
+        return GenerateCtaResponse(success=True, cta=deterministic_pick, used_llm=False)
+
 
 @router.post("/create", response_model=OfferCreationResponse)
 async def create_offer(request: OfferCreationRequest):

--- a/backend/app/routers/pain_point_match.py
+++ b/backend/app/routers/pain_point_match.py
@@ -311,7 +311,7 @@ async def generate_painpoint_matches(request: MatchRequest):
                 value = str(m.get("value") or "").strip()
                 ctx = str(m.get("context") or "").strip()
                 if value:
-                    metric_candidates.append(" — ".join([x for x in [metric, value, ctx] if x]).strip(" —")[:240])
+                    metric_candidates.append(", ".join([x for x in [metric, value, ctx] if x]).strip(", ")[:240])
                 elif metric:
                     metric_candidates.append(f"Qualitative: {metric}"[:240])
         metric_candidates = [x for x in metric_candidates if x and not _is_fluff_line(x)]
@@ -351,7 +351,7 @@ async def generate_painpoint_matches(request: MatchRequest):
                     ctx = str(m.get("context") or "").strip()
                     metric = str(m.get("metric") or "").strip()
                     val = str(m.get("value") or "").strip()
-                    s = " — ".join([x for x in [metric, val, ctx] if x])
+                    s = ", ".join([x for x in [metric, val, ctx] if x])
                     if s and not _is_fluff_line(s):
                         resume_candidates.append(s[:240])
 
@@ -520,7 +520,7 @@ async def generate_painpoint_matches(request: MatchRequest):
                     resume_candidates.append(" ".join(d.split())[:240])
         for m in (resume_parsed.get("keyMetrics") or resume_parsed.get("KeyMetrics") or resume_parsed.get("key_metrics") or [])[:40]:
             if isinstance(m, dict):
-                s = " — ".join([str(m.get("metric") or "").strip(), str(m.get("value") or "").strip(), str(m.get("context") or "").strip()]).strip(" —")
+                s = ", ".join([x for x in [str(m.get("metric") or "").strip(), str(m.get("value") or "").strip(), str(m.get("context") or "").strip()] if x]).strip(", ")
                 if s and not _is_fluff_line(s):
                     resume_candidates.append(" ".join(s.split())[:240])
 

--- a/frontend/src/app/bio-page/page.tsx
+++ b/frontend/src/app/bio-page/page.tsx
@@ -83,7 +83,7 @@ export default function BioPageStep() {
   const [resumeMeta, setResumeMeta] = useState<any>(null);
   const [videoUrl, setVideoUrl] = useState<string>("");
   const [userDisplayName, setUserDisplayName] = useState<string>("");
-  const [openCards, setOpenCards] = useState<Set<string>>(new Set());
+  const [openCards, setOpenCards] = useState<Set<string>>(new Set(["preview"]));
   const [jobPrefs, setJobPrefs] = useState<any>(null);
   const openPublicPage = (url: string, opts?: { preserveHandle?: boolean }): Window | null => {
     const u = safeStr(url);

--- a/frontend/src/app/company-research/page.tsx
+++ b/frontend/src/app/company-research/page.tsx
@@ -1148,66 +1148,6 @@ export default function CompanyResearchPage() {
                   </div>
 
                   <div className="px-4 py-3 space-y-1">
-                    {/* Company Intelligence */}
-                    {draft.intelligence && (draft.intelligence.outreach_summary?.one_liner_hook || draft.intelligence.executive_summary) ? (
-                      <div style={{paddingLeft: 10}}>
-                        <CollapsibleSection title="Company Intelligence" className="mb-0">
-                          {draft.intelligence.executive_summary && (
-                            <div className="mb-3">
-                              <div className="text-[12px] font-semibold text-orange-400 mb-1">Executive Summary</div>
-                              <div className="text-[11.5px] text-white/65 leading-relaxed">{cleanThemeText(draft.intelligence.executive_summary)}</div>
-                            </div>
-                          )}
-                          {draft.intelligence.outreach_summary?.one_liner_hook ? (
-                            <div className="rounded-md border border-blue-500/20 bg-blue-500/10 p-3">
-                              <div className="text-[12px] font-semibold text-orange-400 mb-1">Outreach Summary</div>
-                              <div className="text-[11.5px] text-white/80 mb-2">{draft.intelligence.outreach_summary.one_liner_hook}</div>
-                              {draft.intelligence.outreach_summary.strongest_signal && (
-                                <div className="text-[11.5px] text-white/60 mb-1">
-                                  <span className="text-amber-400 font-semibold text-[10px]">Strongest signal:</span> {draft.intelligence.outreach_summary.strongest_signal}
-                                </div>
-                              )}
-                              {draft.intelligence.outreach_summary.recommended_angle && (
-                                <div className="text-[11.5px] text-white/60 mb-2">
-                                  <span className="text-emerald-400 font-semibold text-[10px]">Recommended angle:</span> {draft.intelligence.outreach_summary.recommended_angle}
-                                </div>
-                              )}
-                              {draft.intelligence.outreach_summary.conversation_starters?.length ? (
-                                <div className="mt-2 pt-2 border-t border-blue-500/15">
-                                  <div className="text-[10px] font-semibold text-orange-300/80 mb-1">Conversation Starters</div>
-                                  {draft.intelligence.outreach_summary.conversation_starters.map((s: string, i: number) => (
-                                    <div key={`cs_${i}`} className="text-[11.5px] text-white/65 mt-0.5 flex items-start gap-1.5">
-                                      <span className="shrink-0 text-blue-300/50 mt-0.5">\u2192</span>
-                                      <span>{s}</span>
-                                    </div>
-                                  ))}
-                                </div>
-                              ) : null}
-                              {draft.intelligence.outreach_summary.sequence_strategy?.length ? (
-                                <div className="mt-2 pt-2 border-t border-blue-500/15">
-                                  <div className="text-[10px] font-semibold text-orange-300/80 mb-1.5">Email Sequence Strategy</div>
-                                  <div className="space-y-1.5">
-                                    {draft.intelligence.outreach_summary.sequence_strategy.map((step: SequenceStep) => (
-                                      <div key={`seq_${step.email_number}`} className="rounded border border-white/10 bg-white/[0.02] p-2">
-                                        <div className="flex items-center gap-2 mb-0.5">
-                                          <span className="inline-block rounded-full bg-blue-500/20 text-blue-300 border border-blue-500/30 px-1.5 py-0.5 text-[9px] font-bold">
-                                            Email {step.email_number}
-                                          </span>
-                                          <span className="text-[10px] text-white/70 font-medium">{step.angle}</span>
-                                        </div>
-                                        {step.subject_line && <div className="text-[10px] text-white/50 mt-0.5"><span className="text-white/30">Subject:</span> {step.subject_line}</div>}
-                                        {step.key_point && <div className="text-[10px] text-white/45 mt-0.5">{step.key_point}</div>}
-                                      </div>
-                                    ))}
-                                  </div>
-                                </div>
-                              ) : null}
-                            </div>
-                          ) : null}
-                        </CollapsibleSection>
-                      </div>
-                    ) : null}
-
                     {/* Select Signals to Break the Ice */}
                     {allSignals.length > 0 ? (
                       <div style={{paddingLeft: 10}}>

--- a/frontend/src/app/find-contact/page.tsx
+++ b/frontend/src/app/find-contact/page.tsx
@@ -523,11 +523,10 @@ export default function FindContactPage() {
 
   const buildDefaultDraft = (c: Contact): OutreachDraft => {
     const first = safeFirstName(c?.name || "");
-    const company = formatCompanyName(String(c?.company || "your team").trim());
-    const title = formatTitleCase(String(c?.title || "").trim());
+    const company = formatCompanyName(String(c?.company || "").trim());
+    const industry = String(c?.job_company_industry || "").trim();
     const m0 = loadPainpointMatch();
     const sol = String(m0?.solution_1 || "").trim();
-    const facts = getInterestingFactsForContact(String(c?.id || ""));
 
     const cleanPhrase = (s: string) => {
       let t = String(s || "").replace(/\s+/g, " ").trim();
@@ -536,7 +535,7 @@ export default function FindContactPage() {
       return t;
     };
 
-    const cta = "Open to connect?";
+    const cta = "Let's connect.";
     const limit = LINKEDIN_NOTE_LIMIT;
 
     const tryFit = (current: string, next: string): string | null => {
@@ -547,28 +546,27 @@ export default function FindContactPage() {
 
     let note = `Hi ${first},`;
 
-    const roleLine = title && company
-      ? `your work as ${title} at ${company} stood out.`
-      : company
-        ? `your work at ${company} stood out.`
-        : "";
-    if (roleLine) {
-      const fit = tryFit(note, `${roleLine.charAt(0).toUpperCase()}${roleLine.slice(1)}`);
+    if (industry && company) {
+      const bridge = `I enjoy connecting with leaders in ${industry.toLowerCase()}, always good to expand the network with people at firms like ${company}.`;
+      const fit = tryFit(note, bridge);
       if (fit) note = fit;
-    }
-
-    const factPhrase = cleanPhrase(String(facts?.[0]?.text || ""));
-    if (factPhrase) {
-      const short = factPhrase.length > 50 ? factPhrase.split(/[,;]/)[0]?.trim() || factPhrase : factPhrase;
-      const factLine = `I noticed ${short.charAt(0).toLowerCase()}${short.slice(1)}.`;
-      const fit = tryFit(note, factLine);
+    } else if (industry) {
+      const bridge = `I enjoy connecting with leaders in ${industry.toLowerCase()}, always good to expand the network.`;
+      const fit = tryFit(note, bridge);
+      if (fit) note = fit;
+    } else if (company) {
+      const bridge = `I reviewed your profile and wanted to connect - always good to expand the network with people at ${company}.`;
+      const fit = tryFit(note, bridge);
+      if (fit) note = fit;
+    } else {
+      const fit = tryFit(note, "I reviewed your profile and wanted to connect.");
       if (fit) note = fit;
     }
 
     const solPhrase = cleanPhrase(sol);
     if (solPhrase) {
       const short = solPhrase.length > 55 ? solPhrase.split(/[,;]/)[0]?.trim() || solPhrase : solPhrase;
-      const solLine = `I ${short.charAt(0).toLowerCase()}${short.slice(1)}.`;
+      const solLine = `I post about ${short.charAt(0).toLowerCase()}${short.slice(1)}.`;
       const fit = tryFit(note, solLine);
       if (fit) note = fit;
     }

--- a/frontend/src/app/offer/page.tsx
+++ b/frontend/src/app/offer/page.tsx
@@ -97,6 +97,9 @@ function metricLine(metric: any, value: any, context: any) {
     if (!t) return "";
     return /[.!?]$/.test(t) ? t : `${t}.`;
   };
+  if (c && m && c.toLowerCase().includes(m.toLowerCase())) {
+    return endSentence(c);
+  }
   if (m && v && c) {
     const byPart = /^by\b/i.test(v) ? `${m} ${v}` : `${m} by ${v}`;
     return `${endSentence(byPart)} ${endSentence(c)}`.trim();
@@ -106,7 +109,7 @@ function metricLine(metric: any, value: any, context: any) {
     return endSentence(byPart);
   }
   if (m && c) return `${endSentence(m)} ${endSentence(c)}`.trim();
-  return m || v || c;
+  return c || m || v;
 }
 
 function ensureSentenceEnd(s: string): string {
@@ -124,24 +127,16 @@ function painPointToOutcome(raw: string): string {
   let s = String(raw || "").trim();
   if (!s) return "";
   s = s
-    .replace(/^(the\s+)?need\s+for\s+(a\s+)?/i, "build ")
+    .replace(/^(the\s+)?need\s+for\s+/i, "")
     .replace(/^(the\s+)?need\s+to\s+/i, "")
-    .replace(/^(the\s+)?lack\s+of\s+(a\s+)?/i, "strengthen ")
-    .replace(/^(the\s+)?absence\s+of\s+(a\s+)?/i, "establish ")
-    .replace(/^(the\s+)?challenge\s+of\s+/i, "tackle ")
-    .replace(/^(the\s+)?difficulty\s+(of|in)\s+/i, "simplify ")
-    .replace(/^(the\s+)?requirement\s+(for|to)\s+/i, "deliver ")
+    .replace(/^(the\s+)?lack\s+of\s+/i, "")
+    .replace(/^(the\s+)?absence\s+of\s+/i, "")
+    .replace(/^(the\s+)?challenge\s+of\s+/i, "")
+    .replace(/^(the\s+)?difficulty\s+(of|in)\s+/i, "")
+    .replace(/^(the\s+)?requirement\s+(for|to)\s+/i, "")
     .replace(/\.\s*$/, "")
     .trim();
   s = lowerFirst(s);
-  if (/^(a|an|the|better|more|improved|scalable|robust|reliable|strong|new|solid|effective)\s/i.test(s)) {
-    s = `build ${s}`;
-  }
-  // Gerund phrases ("enhancing developer productivity") → strip gerund, prepend verb
-  if (/^[a-z]\w+ing\s/i.test(s) && !/^(build|deliver|establish|strengthen|tackle|simplify|turn)/i.test(s)) {
-    const rest = s.slice(s.indexOf(" ") + 1).trim();
-    if (rest) s = `elevate ${rest}`;
-  }
   if (s.length > 60) {
     const short = s.split(/[,;]/)[0]?.trim();
     if (short && short.length >= 15) s = short;
@@ -344,14 +339,18 @@ export default function OfferPage() {
         : "";
 
     let seed = "";
-    if (outcomeRaw) {
-      seed = `I ${outcomeRaw}.`;
+    if (outcomeRaw && title) {
+      seed = `${title} focused on ${outcomeRaw}.`;
+    } else if (outcomeRaw && skillPhrase) {
+      seed = `I help teams achieve ${outcomeRaw} through ${skillPhrase}.`;
+    } else if (outcomeRaw) {
+      seed = `I help organizations achieve ${outcomeRaw}.`;
     } else if (title && skillPhrase) {
-      seed = `${title} who turns ${skillPhrase} into real results.`;
+      seed = `${title} specializing in ${skillPhrase}.`;
     } else if (title) {
-      seed = `${title} who helps teams ship what matters.`;
+      seed = `${title} who helps teams deliver measurable outcomes.`;
     } else if (skillPhrase) {
-      seed = `I turn ${skillPhrase} into real results.`;
+      seed = `I help teams deliver results through ${skillPhrase}.`;
     }
     seed = seed.replace(/\.\./g, ".").replace(/^i\s/i, "I ");
 
@@ -849,7 +848,7 @@ export default function OfferPage() {
                                               const arr = [...(pps || [])];
                                               const idx = arr.findIndex((x) => !String(x || "").trim());
                                               const t = idx >= 0 ? idx : Math.min(arr.length - 1, 5);
-                                              arr[t] = `Pain point: ${clampLines(p, 120)}`;
+                                              arr[t] = clampLines(p, 130);
                                               return arr.slice(0, 6);
                                             });
                                           }

--- a/frontend/src/app/offer/page.tsx
+++ b/frontend/src/app/offer/page.tsx
@@ -23,6 +23,7 @@ type OfferV1 = {
   default_cta: string;
   soft_cta?: string;
   hard_cta?: string;
+  personalized_cta?: string;
   snippet: string; // compiled preview
 };
 
@@ -251,9 +252,10 @@ export default function OfferPage() {
   const [credInput, setCredInput] = useState("");
   const [softCta, setSoftCta] = useState("Worth exploring, or totally not a priority right now?");
   const [defaultCta, setDefaultCta] = useState("Open to a 10-minute chat this week?");
+  const [personalizedCta, setPersonalizedCta] = useState("");
   const [aiSnippet, setAiSnippet] = useState("");
   const [isGeneratingSnippet, setIsGeneratingSnippet] = useState(false);
-  const [isGeneratingCta, setIsGeneratingCta] = useState<"hard" | "soft" | null>(null);
+  const [isGeneratingCta, setIsGeneratingCta] = useState<"hard" | "soft" | "personalized" | null>(null);
   const [showStepHelp, setShowStepHelp] = useState(false);
   const [collapsedSubs, setCollapsedSubs] = useState<Set<string>>(new Set());
 
@@ -320,6 +322,7 @@ export default function OfferPage() {
       setCredibility(savedCred.length ? savedCred : autoCredibility);
       setSoftCta(String(saved.soft_cta || "Worth exploring, or totally not a priority right now?"));
       setDefaultCta(String(saved.hard_cta || saved.default_cta || "Open to a 10-minute chat this week?"));
+      setPersonalizedCta(String(saved.personalized_cta || ""));
       if (!needsOneLinerReseed) return;
     }
 
@@ -427,6 +430,7 @@ export default function OfferPage() {
         default_cta: String(defaultCta || "").trim(),
         soft_cta: String(softCta || "").trim(),
         hard_cta: String(defaultCta || "").trim(),
+        personalized_cta: String(personalizedCta || "").trim(),
         snippet,
       };
       persistOfferForRole(rid, payload, { updateLegacy: Boolean(opts?.updateLegacy) });
@@ -564,6 +568,7 @@ export default function OfferPage() {
           default_cta: String(defaultCta || "").trim(),
           soft_cta: String(softCta || "").trim(),
           hard_cta: String(defaultCta || "").trim(),
+          personalized_cta: String(personalizedCta || "").trim(),
           snippet,
         };
         const key = String(activeRoleId || "").trim() || String(activeRole?.id || "").trim() || "default";
@@ -610,22 +615,26 @@ export default function OfferPage() {
     }
   };
 
-  const generateNewCta = async (ctaType: "hard" | "soft") => {
+  const generateNewCta = async (ctaType: "hard" | "soft" | "personalized") => {
     if (isGeneratingCta) return;
     setIsGeneratingCta(ctaType);
     try {
       const skills = Array.isArray(resume?.skills) ? resume.skills.map((x: any) => String(x || "").trim()).filter(Boolean).slice(0, 6) : [];
+      const painPoints = Array.isArray(activeRole?.painPoints) ? activeRole.painPoints.map((x: any) => String(x || "").trim()).filter(Boolean).slice(0, 3) : [];
+      const currentCta = ctaType === "hard" ? defaultCta : ctaType === "soft" ? softCta : personalizedCta;
       const resp = await api<{ success: boolean; cta: string }>("/offer-creation/generate-cta", "POST", {
         cta_type: ctaType,
-        current_cta: ctaType === "hard" ? defaultCta : softCta,
+        current_cta: currentCta,
         role_title: activeRole?.title || selectedRole?.title || "",
         role_company: activeRole?.company || selectedRole?.company || "",
         skills,
         one_liner: oneLiner,
+        pain_points: painPoints,
       });
       if (resp?.cta) {
         if (ctaType === "hard") setDefaultCta(resp.cta);
-        else setSoftCta(resp.cta);
+        else if (ctaType === "soft") setSoftCta(resp.cta);
+        else setPersonalizedCta(resp.cta);
       }
     } catch {
       setNotice("Couldn't generate CTA right now.");
@@ -691,6 +700,7 @@ export default function OfferPage() {
             existing.soft_cta = String(softCta || "").trim();
             existing.hard_cta = String(defaultCta || "").trim();
             existing.default_cta = String(defaultCta || "").trim();
+            existing.personalized_cta = String(personalizedCta || "").trim();
             break;
         }
 
@@ -1287,6 +1297,33 @@ export default function OfferPage() {
                                 Variable:{" "}
                                 <code className="px-1.5 py-0.5 rounded border border-white/10 bg-black/30 text-emerald-200">
                                   {"{{offer.soft_cta}}"}
+                                </code>
+                              </div>
+                            </div>
+                            <div className="rounded-md border border-white/10 bg-black/20 p-3">
+                              <div className="flex items-center justify-between">
+                                <div className="text-sm font-bold text-emerald-200">Personalized CTA</div>
+                                <button
+                                  type="button"
+                                  disabled={isGeneratingCta === "personalized"}
+                                  onClick={() => generateNewCta("personalized")}
+                                  className="flex items-center gap-1 px-2 py-0.5 rounded border border-emerald-400/30 bg-emerald-400/10 text-[11px] text-emerald-200 hover:bg-emerald-400/20 disabled:opacity-50"
+                                >
+                                  {isGeneratingCta === "personalized" ? <InlineSpinner className="h-3 w-3" /> : null}
+                                  <span>{isGeneratingCta === "personalized" ? "Generating" : personalizedCta ? "Generate new" : "Generate"}</span>
+                                </button>
+                              </div>
+                              <div className="mt-1 text-[11px] text-white/60">Tailored to the role's pain points and your expertise. Click Generate to create one.</div>
+                              <input
+                                value={personalizedCta}
+                                onChange={(e) => setPersonalizedCta(e.target.value)}
+                                className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
+                                placeholder="Click Generate to create a CTA specific to this role and company."
+                              />
+                              <div className="mt-2 text-[11px] text-white/55">
+                                Variable:{" "}
+                                <code className="px-1.5 py-0.5 rounded border border-white/10 bg-black/30 text-emerald-200">
+                                  {"{{offer.personalized_cta}}"}
                                 </code>
                               </div>
                             </div>

--- a/frontend/src/app/offer/page.tsx
+++ b/frontend/src/app/offer/page.tsx
@@ -253,6 +253,7 @@ export default function OfferPage() {
   const [defaultCta, setDefaultCta] = useState("Open to a 10-minute chat this week?");
   const [aiSnippet, setAiSnippet] = useState("");
   const [isGeneratingSnippet, setIsGeneratingSnippet] = useState(false);
+  const [isGeneratingCta, setIsGeneratingCta] = useState<"hard" | "soft" | null>(null);
   const [showStepHelp, setShowStepHelp] = useState(false);
   const [collapsedSubs, setCollapsedSubs] = useState<Set<string>>(new Set());
 
@@ -606,6 +607,31 @@ export default function OfferPage() {
       window.setTimeout(() => setNotice(null), 1500);
     } finally {
       setIsGeneratingSnippet(false);
+    }
+  };
+
+  const generateNewCta = async (ctaType: "hard" | "soft") => {
+    if (isGeneratingCta) return;
+    setIsGeneratingCta(ctaType);
+    try {
+      const skills = Array.isArray(resume?.skills) ? resume.skills.map((x: any) => String(x || "").trim()).filter(Boolean).slice(0, 6) : [];
+      const resp = await api<{ success: boolean; cta: string }>("/offer-creation/generate-cta", "POST", {
+        cta_type: ctaType,
+        current_cta: ctaType === "hard" ? defaultCta : softCta,
+        role_title: activeRole?.title || selectedRole?.title || "",
+        role_company: activeRole?.company || selectedRole?.company || "",
+        skills,
+        one_liner: oneLiner,
+      });
+      if (resp?.cta) {
+        if (ctaType === "hard") setDefaultCta(resp.cta);
+        else setSoftCta(resp.cta);
+      }
+    } catch {
+      setNotice("Couldn't generate CTA right now.");
+      window.setTimeout(() => setNotice(null), 1500);
+    } finally {
+      setIsGeneratingCta(null);
     }
   };
 
@@ -1211,13 +1237,24 @@ export default function OfferPage() {
                           <div className="mt-2">
                           <div className="grid grid-cols-1 gap-4">
                             <div className="rounded-md border border-white/10 bg-black/20 p-3">
-                              <div className="text-sm font-bold text-amber-200">Strong / Hard CTA</div>
+                              <div className="flex items-center justify-between">
+                                <div className="text-sm font-bold text-amber-200">Strong / Hard CTA</div>
+                                <button
+                                  type="button"
+                                  disabled={isGeneratingCta === "hard"}
+                                  onClick={() => generateNewCta("hard")}
+                                  className="flex items-center gap-1 px-2 py-0.5 rounded border border-amber-400/30 bg-amber-400/10 text-[11px] text-amber-200 hover:bg-amber-400/20 disabled:opacity-50"
+                                >
+                                  {isGeneratingCta === "hard" ? <InlineSpinner className="h-3 w-3" /> : null}
+                                  <span>{isGeneratingCta === "hard" ? "Generating" : "Generate new"}</span>
+                                </button>
+                              </div>
                               <div className="mt-1 text-[11px] text-white/60">Ask for clear commitment (time, scheduling, or decision).</div>
                               <input
                                 value={defaultCta}
                                 onChange={(e) => setDefaultCta(e.target.value)}
                                 className="mt-2 w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
-                                placeholder="Can we do 15 minutes next week — Tue 11am or Thu 2pm?"
+                                placeholder="Can we do 15 minutes next week - Tue 11am or Thu 2pm?"
                               />
                               <div className="mt-2 text-[11px] text-white/55">
                                 Variable:{" "}
@@ -1227,7 +1264,18 @@ export default function OfferPage() {
                               </div>
                             </div>
                             <div className="rounded-md border border-white/10 bg-black/20 p-3">
-                              <div className="text-sm font-bold text-sky-200">Soft CTA</div>
+                              <div className="flex items-center justify-between">
+                                <div className="text-sm font-bold text-sky-200">Soft CTA</div>
+                                <button
+                                  type="button"
+                                  disabled={isGeneratingCta === "soft"}
+                                  onClick={() => generateNewCta("soft")}
+                                  className="flex items-center gap-1 px-2 py-0.5 rounded border border-sky-400/30 bg-sky-400/10 text-[11px] text-sky-200 hover:bg-sky-400/20 disabled:opacity-50"
+                                >
+                                  {isGeneratingCta === "soft" ? <InlineSpinner className="h-3 w-3" /> : null}
+                                  <span>{isGeneratingCta === "soft" ? "Generating" : "Generate new"}</span>
+                                </button>
+                              </div>
                               <div className="mt-1 text-[11px] text-white/60">Ask for a low-friction response (easy yes/no or routing).</div>
                               <input
                                 value={softCta}


### PR DESCRIPTION
## Summary
- **Campaign messages**: Strip internal signal labels leaking into email body, fix duplicate "Best," and bio URL, add contextual bio link intro
- **LinkedIn notes**: Rewrite to use shared-industry bridge instead of title-targeting
- **Contact search**: Widen result caps (24->50 pool, 30 final) so seniority filters don't reduce to ~5 results
- **Offer screen**: Fix one-liner grammar, fix proof point redundancy, add Generate New buttons for hard/soft/personalized CTAs
- **Bio page**: Preview starts expanded, slug is now stable and unique per user account
- **Research page**: Strip URLs from prose fields, remove Company Intelligence accordion
- **Find contact**: Apply seniority filter, reject product-name false positives, align level labels

## Test plan
- [ ] Campaign screen: generate step 1 message, verify no "Company theme signal:" labels in output
- [ ] Campaign screen: verify bio link has intro text, not orphaned URL
- [ ] Campaign screen: verify only one "Best," in signature
- [ ] Offer screen: verify one-liner is a proper sentence
- [ ] Offer screen: verify proof points don't repeat metric text
- [ ] Offer screen: click Generate New on each CTA type, verify different output each time
- [ ] Find contact: search with seniority filters, verify 10+ results
- [ ] Find contact: verify LinkedIn note uses industry bridge, not job title
- [ ] Bio page: verify preview section starts expanded
- [ ] Bio page: publish and verify URL is unique and stable on republish
- [ ] Research page: verify no raw URLs in prose fields