### PR TITLE
Fix resume showing fake stub data when OpenAI API fails

### DIFF
--- a/backend/app/routers/resume.py
+++ b/backend/app/routers/resume.py
@@ -407,6 +407,8 @@ async def upload_resume(file: UploadFile = File(...)):
         if client.should_use_real_llm and raw_text:
             try:
                 raw = client.summarize_resume(raw_text)
+                if str(raw.get("id") or "").startswith("stub"):
+                    raise ValueError("OpenAI returned stub; falling back to rule-based parser")
                 choices = raw.get("choices") or []
                 msg = (choices[0].get("message") if choices else {}) or {}
                 content_str = str(msg.get("content") or "")


### PR DESCRIPTION
When OpenAI returns an HTTP error (quota, auth, timeout), the client silently fell back to hardcoded stub data (TechCorp, BlueYonder, etc.) which was then displayed as the actual resume extract.

Now the resume endpoint detects stub responses and falls through to the rule-based parser, which extracts real data from the uploaded PDF text.