### PR TITLE
Fix JSX syntax error breaking frontend build

### DIFF
--- a/frontend/src/app/find-contact/page.tsx
+++ b/frontend/src/app/find-contact/page.tsx
@@ -1299,7 +1299,7 @@ export default function FindContactPage() {
                   handleSearch();
                 }
               }}
-              placeholder='Describe who you\'re looking for, e.g. "5 directors in supply chain and logistics at Thermo Fisher in the US"'
+              placeholder={"Describe who you're looking for, e.g. \"5 directors in supply chain and logistics at Thermo Fisher in the US\""}
               rows={2}
               className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder-white/30 outline-none focus:ring-2 focus:ring-purple-500/50 resize-none"
             />


### PR DESCRIPTION
## Summary
- Fix escaped single quote in JSX attribute (`\'`) that Turbopack rejects
- `find-contact/page.tsx` line 1302: switch to curly-brace expression for the placeholder string

## Context
The Apollo integration merge (PR #235) introduced this syntax. The frontend build fails on Railway with `Parsing ecmascript source code failed`.