### PR TITLE
Fix Smart Search 400 error when prompt parsing fails

### DIFF
--- a/backend/app/routers/find_contact.py
+++ b/backend/app/routers/find_contact.py
@@ -782,6 +782,8 @@ async def search_contacts(request: ContactSearchRequest):
                 logger.debug("Prompt parsing failed, using raw fields: %s", e)
 
         q = (request.company or request.query or "").strip()
+        if not q and request.prompt:
+            q = request.prompt.strip()
         if not q:
             raise HTTPException(status_code=400, detail="Query is required")
 


### PR DESCRIPTION
## Summary
- When using Smart Search, the prompt is sent to OpenAI to extract structured fields (company, role, etc.)
- If parsing fails or returns no company, the query was empty and the backend returned 400 "Query is required"
- Now falls back to using the raw prompt text as the query so the search still works