### PR TITLE
Fix Smart Search company extraction and one-liner grammar

### DIFF
--- a/backend/app/routers/find_contact.py
+++ b/backend/app/routers/find_contact.py
@@ -783,7 +783,11 @@ async def search_contacts(request: ContactSearchRequest):
 
         q = (request.company or request.query or "").strip()
         if not q and request.prompt:
-            q = request.prompt.strip()
+            # Try to extract company name from raw prompt with simple patterns
+            # e.g. "Find me recruiters at Google Cloud" → "Google Cloud"
+            _co_m = re.search(r"\b(?:at|for|from)\s+(.+?)(?:\s+(?:in|within|who|with|that)\b|$)", request.prompt.strip(), re.I)
+            if _co_m:
+                q = _co_m.group(1).strip().rstrip(".,;")
         if not q:
             raise HTTPException(status_code=400, detail="Query is required")
 

--- a/frontend/src/app/offer/page.tsx
+++ b/frontend/src/app/offer/page.tsx
@@ -127,6 +127,8 @@ function lowerFirst(s: string): string {
 function painPointToOutcome(raw: string): string {
   let s = String(raw || "").trim();
   if (!s) return "";
+  // Filter out job posting details that aren't actual pain points
+  if (/\b(application window|deadline|apply by|open until|posting closes)\b/i.test(s)) return "";
   s = s
     .replace(/^(the\s+)?need\s+for\s+/i, "")
     .replace(/^(the\s+)?need\s+to\s+/i, "")
@@ -365,7 +367,7 @@ export default function OfferPage() {
     } else if (skillPhrase) {
       seed = `I help teams deliver results through ${skillPhrase}.`;
     }
-    seed = seed.replace(/\.\./g, ".").replace(/^i\s/i, "I ").replace(/^I'm a a /i, "I'm a ");
+    seed = seed.replace(/\.\./g, ".").replace(/^i\s/i, "I ").replace(/^I'm a a /i, "I'm a ").replace(/\bI'm a ([aeiouAEIOU])/g, "I'm an $1");
 
     setOneLiner(seed);
 


### PR DESCRIPTION
## Summary
- Smart Search: extract company name from prompt with regex ("at X", "for X") instead of sending raw sentence as company query — fixes getting USPS results when searching for Google Cloud
- One-liner: fix "I'm a Executive" → "I'm an Executive" (a/an grammar)
- One-liner: filter out job posting details (application deadlines, posting dates) from pain points so they don't produce garbled sentences