### PR TITLE
feat: Dream 100 flow and prompt overhaul

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -342,8 +342,18 @@ async def authenticate(email: str, password: str) -> Optional[AuthUser]:
     )
 
 
-async def get_current_user_optional(request: Request) -> Optional[AuthUser]:
+def _extract_token(request: Request) -> Optional[str]:
     token = request.cookies.get(settings.auth_cookie_name) if request else None
+    if token:
+        return token
+    auth_header = (request.headers.get("authorization") or "") if request else ""
+    if auth_header.startswith("Bearer "):
+        return auth_header[7:].strip() or None
+    return None
+
+
+async def get_current_user_optional(request: Request) -> Optional[AuthUser]:
+    token = _extract_token(request)
     if not token:
         return None
     try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -105,6 +105,10 @@ def create_app() -> FastAPI:
         from .config import settings as _settings
         token = request.cookies.get(_settings.auth_cookie_name)
         if not token:
+            auth_header = request.headers.get("authorization") or ""
+            if auth_header.startswith("Bearer "):
+                token = auth_header[7:].strip()
+        if not token:
             from starlette.responses import JSONResponse
             return JSONResponse({"detail": "Not authenticated"}, status_code=401)
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -37,6 +37,7 @@ class AuthResponse(BaseModel):
     success: bool
     message: str
     user: Optional[UserProfile] = None
+    token: Optional[str] = None
 
 
 class UpdateMeRequest(BaseModel):
@@ -72,6 +73,7 @@ async def register(req: RegisterRequest, response: Response):
     return AuthResponse(
         success=True,
         message="Account created",
+        token=token,
         user=UserProfile(
             id=user.id,
             email=user.email,
@@ -101,6 +103,7 @@ async def login(req: LoginRequest, response: Response):
     return AuthResponse(
         success=True,
         message="Logged in",
+        token=token,
         user=UserProfile(
             id=user.id,
             email=user.email,
@@ -121,9 +124,11 @@ async def logout(response: Response):
 @router.get("/me", response_model=AuthResponse)
 async def me(request: Request):
     user = await require_current_user(request)
+    token = request.cookies.get(settings.auth_cookie_name) or None
     return AuthResponse(
         success=True,
         message="OK",
+        token=token,
         user=UserProfile(
             id=user.id,
             email=user.email,

--- a/backend/app/routers/campaign.py
+++ b/backend/app/routers/campaign.py
@@ -1052,6 +1052,22 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
                 elif isinstance(sig, str) and sig.strip():
                     _push_unique(company_signals, sig.strip(), 9)
 
+            # Dream 100 brief: if present, inject best_hook as the top-priority contact signal.
+            d100_brief = ctc.get("dream100_brief") if isinstance(ctc, dict) else None
+            if isinstance(d100_brief, dict):
+                bh = str(d100_brief.get("best_hook") or "").strip()
+                if bh:
+                    _push_unique(contact_signals, f"[BEST HOOK] {bh}", 8)
+                oa = str(d100_brief.get("outreach_angle") or "").strip()
+                if oa and not outreach_angles:
+                    outreach_angles = [oa]
+                pp = str(d100_brief.get("pain_points") or "").strip()
+                if pp:
+                    _push_unique(contact_signals, f"Pain points: {pp[:300]}", 8)
+                ts = str(d100_brief.get("tone_style") or "").strip()
+                if ts:
+                    _push_unique(contact_signals, f"Tone/style: {ts}", 8)
+
             # Contact signals from contact research + sourced facts.
             contact_bios = _as_list(ctc.get("contact_bios"))
             b0 = contact_bios[0] if contact_bios and isinstance(contact_bios[0], dict) else {}
@@ -1304,6 +1320,200 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
                 helper={"used_llm": False},
             )
 
+        # Dream 100 mode: activate for ALL steps when positioning context is present.
+        d100 = ctx.get("dream100") if isinstance(ctx, dict) else None
+        if isinstance(d100, dict) and (d100.get("career_result") or d100.get("free_deliverable")) and step in (1, 2, 3, 4):
+
+            # Steps 2 and 3: ultra-short follow-up templates (same message, different day)
+            if step in (2, 3):
+                free_del = str(d100.get("free_deliverable") or "").strip()
+                del_name = free_del if free_del else "the deliverable"
+                contact_obj_s23 = ctx.get("contact") if isinstance(ctx, dict) else {}
+                contact_name_s23 = str((contact_obj_s23 or {}).get("name") or "").strip()
+                first_name_s23 = contact_name_s23.split()[0] if contact_name_s23 else ""
+
+                if step == 2:
+                    body_text = f"still have that {del_name} ready for you. worth sending over?"
+                else:
+                    body_text = f"last follow up — {del_name} is done whenever you want it. happy to share."
+
+                body_with_sig = _append_signature(body_text)
+                body_with_sig = _normalize_message_text(_no_em_dashes(body_with_sig))
+
+                return CampaignGenerateStepResponse(
+                    success=True,
+                    message=f"Generated (Dream 100 step {step})",
+                    subject="",
+                    body=body_with_sig,
+                    helper={
+                        "used_llm": False,
+                        "dream100_mode": True,
+                        "positioning_level": str(d100.get("positioning_level") or "2"),
+                        "dream100_variants": {
+                            "email": {"subject": "", "body": body_with_sig},
+                            "dm": {"body": body_text},
+                            "voice_note": {"script": body_text},
+                        },
+                    },
+                )
+
+            # Step 4: gracious close — short, no pressure, optional referral ask
+            if step == 4:
+                contact_obj_s4 = ctx.get("contact") if isinstance(ctx, dict) else {}
+                contact_name_s4 = str((contact_obj_s4 or {}).get("name") or "").strip()
+                first_name_s4 = contact_name_s4.split()[0] if contact_name_s4 else ""
+                greet_s4 = f"Hi {first_name_s4},\n\n" if first_name_s4 else ""
+                free_del_s4 = str(d100.get("free_deliverable") or "").strip()
+
+                d100_s4_system = (
+                    "You are writing a short, gracious final close — the last message in a Dream 100 outreach sequence.\n\n"
+                    "Rules:\n"
+                    "- NEVER start a sentence with 'I'\n"
+                    "- 2-3 sentences maximum\n"
+                    "- No corporate language, no guilt, no pressure\n"
+                    "- EXACTLY ONE ask: either an easy-out ('completely understand if the timing isn't right') OR a referral ask ('if there's someone else on your team I should connect with, I'd appreciate an intro') — NOT BOTH\n"
+                    "- End graciously\n\n"
+                    "Context:\n"
+                    f"- Contact: {contact_name_s4 or 'the hiring manager'}\n"
+                    f"- Free deliverable offered: {free_del_s4 or '(not specified)'}\n\n"
+                    "Return ONLY valid JSON: { \"body\": \"...\" }"
+                )
+                d100_s4_raw = client.run_chat_completion(
+                    [
+                        {"role": "system", "content": d100_s4_system},
+                        {"role": "user", "content": "Write the closing message."},
+                    ],
+                    temperature=0.35,
+                    max_tokens=300,
+                    stub_json={"body": f"{greet_s4}This will be my last note. If the timing isn't right or you've moved in a different direction, completely understand. If there's someone else on your team I should connect with, I'd appreciate an intro."},
+                )
+                s4_choices = d100_s4_raw.get("choices") or []
+                s4_msg = (s4_choices[0].get("message") if s4_choices else {}) or {}
+                s4_data = extract_json_from_text(str(s4_msg.get("content") or "")) or {}
+                s4_body = str(s4_data.get("body") or "").strip()
+                if not s4_body or len(s4_body) < 20:
+                    s4_body = f"{greet_s4}This will be my last note. If the timing isn't right or you've moved in a different direction, completely understand. If there's someone else on your team I should connect with, I'd appreciate an intro."
+                s4_body = _append_signature(_strip_existing_signature(s4_body))
+                s4_body = _normalize_message_text(_no_em_dashes(s4_body))
+                return CampaignGenerateStepResponse(
+                    success=True,
+                    message="Generated (Dream 100 step 4)",
+                    subject="",
+                    body=s4_body,
+                    helper={"used_llm": True, "dream100_mode": True},
+                )
+
+        # Dream 100 step 1 (kept separate for the 3-variant generation)
+        if step == 1 and isinstance(d100, dict) and (d100.get("career_result") or d100.get("free_deliverable")):
+            positioning_level = str(d100.get("positioning_level") or "2")
+            career_result = str(d100.get("career_result") or "").strip()
+            free_deliverable = str(d100.get("free_deliverable") or "").strip()
+
+            level_strategy = {
+                "1": "They have an open role posted. Reference it directly. Still lead with the deliverable, but acknowledge the posting.",
+                "2": "No exact role posted, but the need clearly exists. Lead with a free insight or mini-deliverable. Do NOT mention looking for a job.",
+                "3": "Hidden market — no role, no signal. Lead with substantial free work. Never hint at job hunting in the first message.",
+            }.get(positioning_level, "Lead with the free deliverable and a specific hook from your research.")
+
+            rb = _build_research_brief(llm_context_obj)
+            contact_sigs = rb.get("contact_signals", []) if isinstance(rb, dict) else []
+            company_sigs = rb.get("company_signals", []) if isinstance(rb, dict) else []
+            outreach_angles = rb.get("outreach_angles", []) if isinstance(rb, dict) else []
+            best_hook_candidates = contact_sigs[:3] + company_sigs[:3]
+
+            contact_obj = ctx.get("contact") if isinstance(ctx, dict) else {}
+            contact_name = str((contact_obj or {}).get("name") or "").strip()
+            contact_title = str((contact_obj or {}).get("title") or "").strip()
+            company_name_d100 = str(ctx.get("company_name") or (contact_obj or {}).get("company") or "").strip()
+
+            d100_system = (
+                "You are an expert cold outreach copywriter trained on the Dream 100 method for job seekers.\n\n"
+                "Your goal: help the sender stand out by leading with a free deliverable — never a resume pitch.\n\n"
+                "POSITIONING CONTEXT:\n"
+                f"- Positioning Level: {positioning_level}\n"
+                f"- Strategy: {level_strategy}\n"
+                f"- Sender's strongest career result: {career_result or '(not provided)'}\n"
+                f"- Free deliverable being offered: {free_deliverable or '(not provided)'}\n"
+                f"- Contact: {contact_name or 'the hiring manager'}{(' (' + contact_title + ')') if contact_title else ''}\n"
+                f"- Company: {company_name_d100 or 'the target company'}\n\n"
+                "RESEARCH SIGNALS (use the best one as the hook):\n"
+                + (("\n".join(f"- {s}" for s in best_hook_candidates[:5])) or "- No specific signals available; reference the company's work generally.")
+                + ("\n\nSuggested outreach angles:\n" + "\n".join(f"- {a}" for a in outreach_angles[:3]) if outreach_angles else "")
+                + "\n\n"
+                "DREAM 100 RULES (enforce all):\n"
+                "- NEVER start a sentence with 'I'\n"
+                "- NO corporate language: no synergy, leverage, passionate about, results-driven, excited to, circle back, reach out\n"
+                "- NO generic compliments: no 'love what you're building', 'huge fan', 'amazing company'\n"
+                "- The HOOK must be SPECIFIC — a real post, stat, announcement, or quote they made. Not vague praise.\n"
+                "- The deliverable must be mentioned naturally — never pitch yourself or a call as the first ask\n"
+                "- NEVER mention the word 'resume' in the first message\n"
+                "- The CTA must always be a soft ask: 'mind if I send it over?' or 'want me to send it over?'\n"
+                "- Write like a peer talking to a peer, not an applicant talking to a gatekeeper\n\n"
+                "Generate THREE versions as a JSON object with keys: email, dm, voice_note.\n\n"
+                "email: cold email\n"
+                "  - subject: lowercase, 2-4 words, curiosity-based (question or tension)\n"
+                "  - body: 3-5 sentences max. Open with the BEST HOOK. Bridge to the deliverable. End with the soft CTA.\n\n"
+                "dm: LinkedIn DM\n"
+                "  - body: 2-4 sentences max. Even more casual than the email. Same hook, same deliverable, same CTA.\n\n"
+                "voice_note: Loom/voice note script\n"
+                "  - script: 30-45 second spoken script. Open with hook. Explain deliverable in one sentence. End with CTA. Write exactly how you'd say it out loud — no formal language.\n\n"
+                "Return ONLY valid JSON: { \"email\": { \"subject\": \"...\", \"body\": \"...\" }, \"dm\": { \"body\": \"...\" }, \"voice_note\": { \"script\": \"...\" } }\n"
+            )
+
+            d100_messages = [
+                {"role": "system", "content": d100_system},
+                {"role": "user", "content": f"Research context:\n{json.dumps(_compact_context(llm_context_obj), ensure_ascii=False)[:3000]}"},
+            ]
+
+            d100_raw = client.run_chat_completion(
+                d100_messages,
+                temperature=0.4,
+                max_tokens=1200,
+                stub_json={
+                    "email": {"subject": "quick question", "body": "Saw your recent work and put together a quick teardown. mind if I send it over?"},
+                    "dm": {"body": "Put something together for you — mind if I send it over?"},
+                    "voice_note": {"script": "Hey, saw your recent work on [topic] and put together a quick deliverable for you. Takes about two minutes to look at. Want me to send it over?"},
+                },
+            )
+
+            d100_choices = d100_raw.get("choices") or []
+            d100_msg = (d100_choices[0].get("message") if d100_choices else {}) or {}
+            d100_content = str(d100_msg.get("content") or "")
+            d100_data = extract_json_from_text(d100_content) or {}
+
+            email_v = d100_data.get("email") or {}
+            dm_v = d100_data.get("dm") or {}
+            voice_v = d100_data.get("voice_note") or {}
+
+            d100_subject = str(email_v.get("subject") or "").strip().lower() or "quick question"
+            d100_email_body = str(email_v.get("body") or "").strip()
+            d100_dm_body = str(dm_v.get("body") or "").strip()
+            d100_voice_script = str(voice_v.get("script") or "").strip()
+
+            d100_email_body = _normalize_message_text(_no_em_dashes(
+                _append_signature(_strip_existing_signature(_strip_fluff_openers(d100_email_body)))
+            ))
+            d100_subject = _normalize_message_text(_no_em_dashes(d100_subject))[:100]
+            d100_dm_body = _normalize_message_text(_no_em_dashes(d100_dm_body))
+            d100_voice_script = _normalize_message_text(_no_em_dashes(d100_voice_script))
+
+            return CampaignGenerateStepResponse(
+                success=True,
+                message="Generated (Dream 100 mode)",
+                subject=d100_subject,
+                body=d100_email_body,
+                helper={
+                    "used_llm": True,
+                    "dream100_mode": True,
+                    "positioning_level": positioning_level,
+                    "dream100_variants": {
+                        "email": {"subject": d100_subject, "body": d100_email_body},
+                        "dm": {"body": d100_dm_body},
+                        "voice_note": {"script": d100_voice_script},
+                    },
+                },
+            )
+
         # Step-specific intent -- each email must take a DIFFERENT angle.
         step_intent = {
             1: (
@@ -1380,15 +1590,22 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
             "Happy to share specifics if helpful.\n\nJohn\"\n\n"
             "EXAMPLE of a good Step 4 (breakup):\n"
             "\"Hi Sarah,\n\n"
-            "This will be my last note. If the timing isn't right or the role's been filled, completely understand. "
-            "If there's someone else on your team I should connect with, I'd appreciate an intro.\n\n"
+            "This will be my last note. If the timing isn't right or the role's been filled, completely understand.\n\n"
             "Thanks for your time,\nJohn\"\n\n"
+            "OR (with referral ask instead of easy-out):\n"
+            "\"Hi Sarah,\n\n"
+            "This will be my last note. If there's someone else on your team I should connect with, I'd appreciate an intro.\n\n"
+            "Thanks,\nJohn\"\n\n"
+            "Rule: pick ONE of these. Never include both in the same message.\n\n"
             "Hard style constraints:\n"
             "- Do NOT use em dashes or en dashes. Use commas, parentheses, or simple hyphens.\n"
-            "- Hard ban: no canned openers like 'I hope you're doing well'.\n"
+            "- EXACTLY ONE ask per email. One CTA, full stop. Never include both an easy-out and a referral ask — pick one.\n"
+            "- Hard ban: no canned openers like 'I hope you're doing well', 'I wanted to reach out', 'I came across', 'I noticed that', 'I recently saw', 'I hope this finds you'.\n"
             "- After any greeting, the next sentence must be value-first (offer/painpoint/proof/ask).\n"
             "- Keep it plain-language and specific.\n"
-            "- Avoid startup jargon (e.g., 'ship outcomes', 'drive impact', 'move the needle'). Prefer human phrasing.\n"
+            "- Avoid startup jargon (e.g., 'ship outcomes', 'drive impact', 'move the needle', 'synergy', 'leverage', 'circle back', 'results-driven', 'passionate about'). Prefer human phrasing.\n"
+            "- Sentences must flow naturally — each sentence follows logically from the last. No jarring topic jumps between sentences.\n"
+            "- Write as if sending from your personal email, not composing a business letter. Short sentences. Natural rhythm.\n"
             "- Voice must be first-person singular for an individual job seeker: use I/me/my, not we/us/our.\n"
             "- Use real names/companies ONLY if provided in the context JSON. Do not invent.\n"
             "- Do NOT output template placeholders like {{first_name}}.\n"

--- a/backend/app/routers/context_research.py
+++ b/backend/app/routers/context_research.py
@@ -315,6 +315,15 @@ class CompanySignal(BaseModel):
     value: str
     category: str
 
+class Dream100Brief(BaseModel):
+    best_hook: str = ""
+    company_summary: str = ""
+    team_function_context: str = ""
+    pain_points: str = ""
+    tone_style: str = ""
+    recent_news_highlight: str = ""
+    outreach_angle: str = ""
+
 class ResearchData(BaseModel):
     company_summary: CompanySummary
     contact_bios: List[ContactBio]
@@ -332,6 +341,7 @@ class ResearchData(BaseModel):
     background_report_sections: Optional[List[Dict[str, Any]]] = None
     intelligence: Optional[CompanyIntelligence] = None
     company_signals: Optional[List[CompanySignal]] = None
+    dream100_brief: Optional[Dream100Brief] = None
 
 class ResearchRequest(BaseModel):
     contact_ids: List[str]
@@ -883,6 +893,24 @@ def _parse_intelligence(raw: Any) -> Optional[CompanyIntelligence]:
             outreach_summary=outreach_summary,
             executive_summary=str(raw.get("executive_summary") or "").strip()[:1500],
             overall_relevance_score=min(1.0, max(0.0, float(raw.get("overall_relevance_score") or 0.0))),
+        )
+    except Exception:
+        return None
+
+
+def _parse_dream100_brief(raw: Any) -> Optional["Dream100Brief"]:
+    """Parse the dream100_brief block from LLM output."""
+    if not raw or not isinstance(raw, dict):
+        return None
+    try:
+        return Dream100Brief(
+            best_hook=_strip_likely_language(str(raw.get("best_hook") or "").strip()),
+            company_summary=_strip_likely_language(str(raw.get("company_summary") or "").strip()),
+            team_function_context=_strip_likely_language(str(raw.get("team_function_context") or "").strip()),
+            pain_points=_strip_likely_language(str(raw.get("pain_points") or "").strip()),
+            tone_style=_strip_likely_language(str(raw.get("tone_style") or "").strip()),
+            recent_news_highlight=_strip_likely_language(str(raw.get("recent_news_highlight") or "").strip()),
+            outreach_angle=_strip_likely_language(str(raw.get("outreach_angle") or "").strip()),
         )
     except Exception:
         return None
@@ -2143,6 +2171,16 @@ async def conduct_research(request: ResearchRequest):
                     "        Email 1: lead with the strongest signal/hook. Email 2: follow up with a different angle (company news, mutual interest). Email 3: breakup email with a soft CTA.\n"
                     "    - executive_summary: 3-5 sentence executive briefing on the company's current trajectory and what it means for outreach\n"
                     "    - overall_relevance_score: float 0.0-1.0 (how relevant is this company to the job seeker based on signals)\n"
+                    "  - dream100_brief: object with keys (Dream 100 method outreach brief — be specific, no filler):\n"
+                    "    - best_hook: ONE specific, verifiable, impressive thing this person or company has publicly said or achieved.\n"
+                    "      Must be a real post, stat, announcement, quote, or milestone. NOT a generic compliment.\n"
+                    "      Example: 'Sarah posted on LinkedIn that their trial-to-paid conversion dropped after switching ESPs and she is rebuilding from scratch.'\n"
+                    "    - company_summary: What the company sells and who they sell it to. 2 sentences max.\n"
+                    "    - team_function_context: What this hiring manager's team owns and what success looks like for them. 2 sentences.\n"
+                    "    - pain_points: Problems or gaps they have publicly talked about, especially ones a job seeker could solve. 2-4 bullet points as a single string.\n"
+                    "    - tone_style: How the hiring manager communicates (casual, formal, tactical, visionary, data-driven). 1 sentence based on their posts or profile.\n"
+                    "    - recent_news_highlight: The single most notable recent thing about the company or this person. 1-2 sentences.\n"
+                    "    - outreach_angle: Recommended angle for cold outreach based on all of the above. What to lead with and what free thing to offer. 2-3 sentences.\n"
                     "- hooks: array of short talking points for outreach\n"
                 ),
             },
@@ -2422,6 +2460,7 @@ async def conduct_research(request: ResearchRequest):
                     cs,
                     apollo_company=corpus.get("apollo_company_enrich"),
                 ),
+                dream100_brief=_parse_dream100_brief(entry.get("dream100_brief")),
             )
 
         # Back-compat: also return a single research_data (first contact).

--- a/frontend/src/app/campaign/CampaignV2.tsx
+++ b/frontend/src/app/campaign/CampaignV2.tsx
@@ -7,7 +7,41 @@ import { persistCampaignContextV1 } from "@/lib/campaignContext";
 import { formatCompanyName } from "@/lib/format";
 import InlineSpinner from "@/components/InlineSpinner";
 
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = () => {
+    if (!text) return;
+    navigator.clipboard.writeText(text).catch(() => {
+      const ta = document.createElement("textarea");
+      ta.value = text;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand("copy");
+      document.body.removeChild(ta);
+    });
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="text-[10px] text-white/50 hover:text-white/80 border border-white/10 hover:border-white/30 rounded px-1.5 py-0.5 transition-colors"
+    >
+      {copied ? "Copied!" : "Copy"}
+    </button>
+  );
+}
+
 type Mode = "job-seeker" | "recruiter";
+
+type Dream100VariantTab = "email" | "dm" | "voice_note";
+
+type Dream100Variants = {
+  email: { subject: string; body: string };
+  dm: { body: string };
+  voice_note: { script: string };
+};
 
 type BaseTone =
   | "recruiter"
@@ -88,6 +122,16 @@ type CampaignV2 = {
 const STORAGE_V2 = "rf_campaign_by_contact_v2";
 const STORAGE_ACTIVE = "rf_campaign_active_contact_id";
 const STORAGE_PERSISTED = "rf_persisted_campaign_meta_v1"; // { id, name }
+const STORAGE_OUTREACH_STATUS = "rf_outreach_status";
+
+type OutreachStatus = "none" | "day1" | "day3" | "day7" | "closed";
+const OUTREACH_STATUS_OPTIONS: { value: OutreachStatus; label: string; color: string }[] = [
+  { value: "none",   label: "Not sent",   color: "border-white/10 text-white/40 bg-transparent" },
+  { value: "day1",   label: "Day 1 sent", color: "border-blue-500/40 text-blue-300 bg-blue-600/15" },
+  { value: "day3",   label: "Day 3 sent", color: "border-yellow-500/40 text-yellow-300 bg-yellow-600/10" },
+  { value: "day7",   label: "Day 7 sent", color: "border-orange-500/40 text-orange-300 bg-orange-600/10" },
+  { value: "closed", label: "Closed out", color: "border-white/20 text-white/50 bg-white/5" },
+];
 
 const BASE_TONES: Tone[] = ["recruiter", "manager", "exec", "developer", "sales", "startup", "enterprise", "custom"];
 const EMAIL4_EXTRA_TONES: Tone[] = ["hilarious", "silly", "wacky", "alarmist", "flirty", "sad", "ridiculous"];
@@ -162,30 +206,35 @@ function defaultToneForStep(step: 1 | 2 | 3 | 4): Tone {
 function defaultInstructions(step: 1 | 2 | 3 | 4) {
   if (step === 1) {
     return [
-      "Write a concise, human first email that feels personally written to this person.",
-      "No fluff openers. Lead with a concrete value/idea and one credibility proof.",
-      "Use specifics from the selected context layers, but do not overstuff.",
-      "End with a simple CTA (10–15 min chat).",
+      "Dream 100 step 1 — Day 1 initial outreach.",
+      "Open with ONE specific, verifiable hook about this person or their company (a real post, stat, announcement, or quote — not a generic compliment).",
+      "Bridge to the free deliverable in one sentence.",
+      "End with the soft CTA: 'mind if I send it over?' — never pitch a call or a resume.",
+      "3-5 sentences max. Write like a peer, not an applicant.",
+      "Never start a sentence with 'I'. No corporate language.",
     ].join("\n");
   }
   if (step === 2) {
     return [
-      "Follow up briefly. Assume they are busy, not ignoring you.",
-      "Add one additional helpful detail or angle (not a repeat).",
-      "Keep it short and easy to respond to.",
+      "Dream 100 step 2 — Day 3 follow-up.",
+      "One sentence only. Remind them the deliverable is ready.",
+      "Template: 'still have that [deliverable] ready for you. worth sending over?'",
+      "Do not add context, explanation, or a new pitch. Same message, shorter.",
     ].join("\n");
   }
   if (step === 3) {
     return [
-      "Follow up again with a different angle: alternative proof, different benefit, or a short 2–3 bullet plan.",
-      "Warm and respectful. No guilt. No pressure.",
+      "Dream 100 step 3 — Day 7 final follow-up.",
+      "One sentence only. The deliverable is done and ready to send.",
+      "Template: 'last follow up — [deliverable] is done whenever you want it. happy to share.'",
+      "No pressure, no guilt, no added content.",
     ].join("\n");
   }
   return [
-    "Final follow-up. This is a respectful 'breakup' message.",
-    "If tone is playful/wacky.",
-    "Give them an easy out (reply 'no') and an easy yes (quick chat).",
-    "This is a first-person job seeker contacting a hiring decision maker.  It should should sound person, relatable, human, friendly, and not corporate, salesy or too canned.",
+    "Dream 100 step 4 — Gracious close.",
+    "2-3 sentences. Acknowledge they are busy. Give them an easy out.",
+    "Optionally include a referral ask: 'if there's someone else on your team I should connect with, I'd appreciate an intro.'",
+    "Never start a sentence with 'I'. No corporate language. Not salesy or canned.",
   ].join("\n");
 }
 
@@ -253,9 +302,10 @@ function layerLabel(id: ContextLayerId) {
 }
 
 function emailLabelForNumber(n: number) {
-  if (n === 1) return "Initial";
-  if (n === 4) return "Final check-in";
-  return "Follow-up";
+  if (n === 1) return "Day 1 — Initial Outreach";
+  if (n === 2) return "Day 3 — Follow-Up";
+  if (n === 3) return "Day 7 — Final Follow-Up";
+  return "Breakup / Close";
 }
 
 function recommendedCtaType(stepNumber: number): "Soft CTA" | "Hard CTA" {
@@ -297,6 +347,9 @@ export default function CampaignV2() {
   const [bioUrl, setBioUrl] = useState<string>("");
 
   const [openAccordions, setOpenAccordions] = useState<Record<string, { layers: boolean; instructions: boolean }>>({});
+  const [dream100VariantsByStep, setDream100VariantsByStep] = useState<Record<string, Dream100Variants>>({});
+  const [outreachStatus, setOutreachStatus] = useState<Record<string, OutreachStatus>>({});
+  const [activeVariantTab, setActiveVariantTab] = useState<Record<string, Dream100VariantTab>>({});
 
   // Persisted campaign (DB) metadata
   const [persistedCampaignId, setPersistedCampaignId] = useState<string>("");
@@ -340,6 +393,9 @@ export default function CampaignV2() {
 
     const by = safeJson<Record<string, CampaignV2>>(localStorage.getItem(STORAGE_V2), {});
     setCampaignByContact(by || {});
+
+    const savedStatus = safeJson<Record<string, OutreachStatus>>(localStorage.getItem(STORAGE_OUTREACH_STATUS), {});
+    setOutreachStatus(savedStatus || {});
 
     const savedActive = String(localStorage.getItem(STORAGE_ACTIVE) || "").trim();
     const fallback = selectedContacts?.[0]?.id ? String(selectedContacts[0].id) : "";
@@ -509,7 +565,7 @@ export default function CampaignV2() {
         sender_profile: ctx.sender_profile as SenderProfile,
       };
 
-      const res = await api<{ success: boolean; subject: string; body: string; message?: string }>(
+      const res = await api<{ success: boolean; subject: string; body: string; message?: string; helper?: any }>(
         "/campaign/generate-step",
         "POST",
         payload
@@ -521,6 +577,13 @@ export default function CampaignV2() {
         body: cleanMessageText(res.body || ""),
         last_generated_at: nowIso(),
       });
+
+      const d100v = res?.helper?.dream100_variants;
+      if (d100v && step.step_number === 1) {
+        const stepKey = `${cid}_e1`;
+        setDream100VariantsByStep((prev) => ({ ...prev, [stepKey]: d100v as Dream100Variants }));
+        setActiveVariantTab((prev) => ({ ...prev, [stepKey]: "email" }));
+      }
     } catch (e: any) {
       setError(String(e?.message || "Failed to generate."));
     } finally {
@@ -752,6 +815,14 @@ export default function CampaignV2() {
     if (!expandedContacts.has(cid)) setActive(cid);
   };
 
+  const updateOutreachStatus = (cid: string, status: OutreachStatus) => {
+    setOutreachStatus((prev) => {
+      const next = { ...prev, [cid]: status };
+      try { localStorage.setItem(STORAGE_OUTREACH_STATUS, JSON.stringify(next)); } catch {}
+      return next;
+    });
+  };
+
   const toggleEmail = (key: string) => {
     setExpandedEmails((prev) => {
       const next = new Set(prev);
@@ -770,6 +841,9 @@ export default function CampaignV2() {
     const emailKey = `${cid}_e${step.step_number}`;
     const isEmailOpen = expandedEmails.has(emailKey);
     const hasContent = Boolean(step.subject || step.body);
+    const d100Variants = dream100VariantsByStep[emailKey];
+    const activeTab: Dream100VariantTab = activeVariantTab[emailKey] || "email";
+
 
     return (
       <div key={step.id} className="rounded-lg border border-white/10 bg-black/20 overflow-hidden" style={{ marginLeft: 14 }}>
@@ -955,27 +1029,134 @@ export default function CampaignV2() {
               ) : null}
             </div>
 
-            <div className="mt-4 space-y-3">
-              <div>
-                <div className="text-xs font-semibold text-white/70 uppercase tracking-wider mb-1">Subject</div>
-                <input
-                  value={String(step.subject || "")}
-                  onChange={(e) => updateStep(cid, step.id, { subject: e.target.value })}
-                  className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="Generate to fill..."
-                />
+            {d100Variants ? (
+              <div className="mt-4 space-y-3">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="inline-flex items-center rounded-full border border-blue-400/40 bg-blue-600/20 px-2.5 py-0.5 text-[11px] font-semibold text-blue-200 uppercase tracking-wider">
+                    Dream 100 Mode
+                  </span>
+                  <span className="text-[11px] text-white/40">Select a format to use</span>
+                </div>
+                <div className="flex gap-1 rounded-lg border border-white/10 bg-black/30 p-1">
+                  {(["email", "dm", "voice_note"] as Dream100VariantTab[]).map((tab) => (
+                    <button
+                      key={tab}
+                      type="button"
+                      onClick={() => {
+                        setActiveVariantTab((prev) => ({ ...prev, [emailKey]: tab }));
+                        if (tab === "email") {
+                          updateStep(cid, step.id, {
+                            subject: cleanMessageText(d100Variants.email.subject),
+                            body: cleanMessageText(d100Variants.email.body),
+                          });
+                        } else if (tab === "dm") {
+                          updateStep(cid, step.id, {
+                            subject: "",
+                            body: cleanMessageText(d100Variants.dm.body),
+                          });
+                        } else {
+                          updateStep(cid, step.id, {
+                            subject: "",
+                            body: cleanMessageText(d100Variants.voice_note.script),
+                          });
+                        }
+                      }}
+                      className={`flex-1 py-1.5 text-xs font-semibold rounded-md transition-colors ${
+                        activeTab === tab
+                          ? "bg-blue-600 text-white"
+                          : "text-white/60 hover:text-white hover:bg-white/10"
+                      }`}
+                    >
+                      {tab === "email" ? "Cold Email" : tab === "dm" ? "LinkedIn DM" : "Voice Note / Loom"}
+                    </button>
+                  ))}
+                </div>
+
+                {activeTab !== "voice_note" && (
+                  <div>
+                    <div className="text-xs font-semibold text-white/70 uppercase tracking-wider mb-1">Subject</div>
+                    <input
+                      value={String(step.subject || "")}
+                      onChange={(e) => updateStep(cid, step.id, { subject: e.target.value })}
+                      className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
+                      placeholder={activeTab === "dm" ? "No subject for DMs" : "Generate to fill..."}
+                    />
+                  </div>
+                )}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="text-xs font-semibold text-white/70 uppercase tracking-wider">
+                      {activeTab === "voice_note" ? "Script" : "Body"}
+                    </div>
+                    {step.body && (
+                      <CopyButton text={String(step.body || "")} />
+                    )}
+                  </div>
+                  <textarea
+                    value={String(step.body || "")}
+                    onChange={(e) => updateStep(cid, step.id, { body: e.target.value })}
+                    rows={activeTab === "voice_note" ? 6 : 8}
+                    className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500 whitespace-pre-wrap"
+                    placeholder="Generate to fill..."
+                  />
+                  {activeTab === "voice_note" && (
+                    <p className="mt-1 text-[11px] text-white/40">30–45 second spoken script. Read exactly as written.</p>
+                  )}
+                </div>
+
+                <div className="rounded-lg border border-white/10 bg-black/30 p-4 mt-2">
+                  <div className="text-xs font-semibold text-white/60 uppercase tracking-wider mb-3">Dream 100 Follow-Up Sequence</div>
+                  <div className="space-y-3 text-sm">
+                    <div className="flex gap-3">
+                      <span className="shrink-0 w-14 text-[11px] font-bold text-blue-300 pt-0.5">Day 1</span>
+                      <span className="text-white/70">Your initial outreach above. Generate Email 2 (Day 3) and Email 3 (Day 7) below — they will use the Dream 100 follow-up templates automatically.</span>
+                    </div>
+                    <div className="flex gap-3">
+                      <span className="shrink-0 w-14 text-[11px] font-bold text-blue-300 pt-0.5">Day 3</span>
+                      <div className="text-white/70">
+                        <span className="font-mono text-xs text-white/50 block mb-1">One sentence — no new context:</span>
+                        still have that <span className="text-white font-medium">[deliverable]</span> ready for you. worth sending over?
+                      </div>
+                    </div>
+                    <div className="flex gap-3">
+                      <span className="shrink-0 w-14 text-[11px] font-bold text-blue-300 pt-0.5">Day 7</span>
+                      <div className="text-white/70">
+                        <span className="font-mono text-xs text-white/50 block mb-1">Last follow-up:</span>
+                        last follow up — <span className="text-white font-medium">[deliverable]</span> is done whenever you want it. happy to share.
+                      </div>
+                    </div>
+                    <p className="text-[11px] text-white/40 mt-2 pt-2 border-t border-white/10">
+                      Rule: same message, three times. Don&apos;t add context. Don&apos;t apologize. The only ask is &ldquo;want to see the thing I made?&rdquo;
+                    </p>
+                  </div>
+                </div>
               </div>
-              <div>
-                <div className="text-xs font-semibold text-white/70 uppercase tracking-wider mb-1">Body</div>
-                <textarea
-                  value={String(step.body || "")}
-                  onChange={(e) => updateStep(cid, step.id, { body: e.target.value })}
-                  rows={8}
-                  className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500 whitespace-pre-wrap"
-                  placeholder="Generate to fill..."
-                />
+            ) : (
+              <div className="mt-4 space-y-3">
+                <div>
+                  <div className="text-xs font-semibold text-white/70 uppercase tracking-wider mb-1">Subject</div>
+                  <input
+                    value={String(step.subject || "")}
+                    onChange={(e) => updateStep(cid, step.id, { subject: e.target.value })}
+                    className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
+                    placeholder="Generate to fill..."
+                  />
+                </div>
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="text-xs font-semibold text-white/70 uppercase tracking-wider">Body</div>
+                    {step.body && <CopyButton text={String(step.body || "")} />}
+                  </div>
+                  <textarea
+                    value={String(step.body || "")}
+                    onChange={(e) => updateStep(cid, step.id, { body: e.target.value })}
+                    rows={8}
+                    className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500 whitespace-pre-wrap"
+                    placeholder="Generate to fill..."
+                  />
+                </div>
               </div>
-            </div>
+            )}
           </div>
         )}
       </div>
@@ -995,7 +1176,7 @@ export default function CampaignV2() {
           <div className="mb-6">
             <h1 className="text-3xl font-bold text-white mb-1">Email Campaign</h1>
             <p className="text-white/70 text-sm">
-              Expand a contact to generate their 4-email outreach sequence. Each email draws from your resume, offer, company research, pain points, and contact signals.
+              Dream 100 outreach sequence: Day 1 initial outreach with a specific hook and deliverable offer, Day 3 and Day 7 short follow-ups, then a gracious close. Fill in your positioning on the Role Prefs page to activate Dream 100 mode.
             </p>
           </div>
 
@@ -1141,12 +1322,24 @@ export default function CampaignV2() {
                                     <span className="text-xs text-white/50 truncate">{String(c?.title || "Decision maker")}</span>
                                   </div>
                                 </div>
-                                <div className="flex items-center gap-2 shrink-0">
+                                <div className="flex items-center gap-2 shrink-0" onClick={(e) => e.stopPropagation()}>
                                   {emailCount > 0 && (
                                     <span className="inline-flex items-center px-2 py-0.5 rounded-full border border-emerald-400/20 bg-emerald-500/10 text-[10px] text-emerald-200">
                                       {emailCount}/4 drafted
                                     </span>
                                   )}
+                                  <select
+                                    value={outreachStatus[cid] || "none"}
+                                    onChange={(e) => updateOutreachStatus(cid, e.target.value as OutreachStatus)}
+                                    onClick={(e) => e.stopPropagation()}
+                                    className={`text-[10px] rounded border px-1.5 py-0.5 bg-transparent outline-none cursor-pointer ${
+                                      OUTREACH_STATUS_OPTIONS.find(o => o.value === (outreachStatus[cid] || "none"))?.color || ""
+                                    }`}
+                                  >
+                                    {OUTREACH_STATUS_OPTIONS.map(o => (
+                                      <option key={o.value} value={o.value} className="bg-gray-900 text-white">{o.label}</option>
+                                    ))}
+                                  </select>
                                 </div>
                               </button>
 

--- a/frontend/src/app/find-contact/page.tsx
+++ b/frontend/src/app/find-contact/page.tsx
@@ -1841,6 +1841,43 @@ export default function FindContactPage() {
                             {isResearchingThis ? <><InlineSpinner /> Researching...</> : "Research this person"}
                           </button>
 
+                          {/* Dream 100 Brief — shown when research has run */}
+                          {(() => {
+                            const d100b = (research as any)?.dream100_brief;
+                            if (!d100b || (!d100b.best_hook && !d100b.outreach_angle)) return null;
+                            return (
+                              <div className="rounded-lg border border-blue-500/30 bg-blue-600/10 p-3 space-y-2">
+                                <div className="flex items-center gap-2">
+                                  <span className="text-[10px] font-bold text-blue-300 uppercase tracking-wider">Dream 100 Brief</span>
+                                </div>
+                                {d100b.best_hook && (
+                                  <div>
+                                    <div className="text-[10px] font-semibold text-white/50 uppercase tracking-wider mb-0.5">Best Hook</div>
+                                    <div className="text-[11px] text-white/80 leading-relaxed">{d100b.best_hook}</div>
+                                  </div>
+                                )}
+                                {d100b.pain_points && (
+                                  <div>
+                                    <div className="text-[10px] font-semibold text-white/50 uppercase tracking-wider mb-0.5">Pain Points</div>
+                                    <div className="text-[11px] text-white/70 leading-relaxed whitespace-pre-line">{d100b.pain_points}</div>
+                                  </div>
+                                )}
+                                {d100b.tone_style && (
+                                  <div>
+                                    <div className="text-[10px] font-semibold text-white/50 uppercase tracking-wider mb-0.5">Tone / Style</div>
+                                    <div className="text-[11px] text-white/70">{d100b.tone_style}</div>
+                                  </div>
+                                )}
+                                {d100b.outreach_angle && (
+                                  <div>
+                                    <div className="text-[10px] font-semibold text-white/50 uppercase tracking-wider mb-0.5">Outreach Angle</div>
+                                    <div className="text-[11px] text-white/80 leading-relaxed">{d100b.outreach_angle}</div>
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })()}
+
                           {hooks.length ? (
                             <div className="text-[11px] text-white/70">
                               <span className="font-semibold text-white/80">Personalization:</span>{" "}

--- a/frontend/src/app/gap-analysis/page.tsx
+++ b/frontend/src/app/gap-analysis/page.tsx
@@ -255,6 +255,15 @@ export default function GapAnalysisPage() {
       setHelper(nextHelper);
       try { localStorage.setItem("gap_analysis_ranked", JSON.stringify(nextRanked)); } catch {}
       try { localStorage.setItem("gap_analysis_helper", JSON.stringify(nextHelper)); } catch {}
+      // Also write keys that campaignContext.ts reads so the "Gaps" layer is populated.
+      try {
+        const byJob: Record<string, GapAnalysisItem> = {};
+        for (const item of nextRanked) {
+          if (item.job_id) byJob[item.job_id] = item;
+        }
+        localStorage.setItem("gap_analysis_results_by_job", JSON.stringify(byJob));
+        localStorage.setItem("gap_analysis_results", JSON.stringify(nextRanked));
+      } catch {}
     } catch (e: any) {
       setError(e?.message || "Failed to run gap analysis.");
     } finally {
@@ -300,6 +309,14 @@ export default function GapAnalysisPage() {
     setRanked((prev) => {
       const next = (prev || []).filter((r) => String(r.job_id || "") !== id);
       try { localStorage.setItem("gap_analysis_ranked", JSON.stringify(next)); } catch {}
+      try {
+        const byJob: Record<string, GapAnalysisItem> = {};
+        for (const item of next) {
+          if (item.job_id) byJob[item.job_id] = item;
+        }
+        localStorage.setItem("gap_analysis_results_by_job", JSON.stringify(byJob));
+        localStorage.setItem("gap_analysis_results", JSON.stringify(next));
+      } catch {}
       return next;
     });
     setExpandedJobIds((prev) => { const next = new Set(prev); next.delete(id); return next; });

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -92,6 +92,7 @@ export default function LoginPage() {
         });
         if (!resp?.success) throw new Error(resp?.message || "Failed to create account.");
         if (resp?.user) localStorage.setItem("rf_user", JSON.stringify(resp.user));
+        if (resp?.token) localStorage.setItem("rf_token", resp.token);
       } else {
         if (!email.trim()) throw new Error("Email is required.");
         if (!password) throw new Error("Password is required.");
@@ -100,6 +101,7 @@ export default function LoginPage() {
         const resp = await api<any>("/auth/login", "POST", { email, password });
         if (!resp?.success) throw new Error(resp?.message || "Failed to log in.");
         if (resp?.user) localStorage.setItem("rf_user", JSON.stringify(resp.user));
+        if (resp?.token) localStorage.setItem("rf_token", resp.token);
       }
 
       window.location.href = "/job-preferences";

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -42,6 +42,7 @@ export default function Navbar() {
           localStorage.setItem("rf_user", JSON.stringify(resp.user));
           setUser(resp.user);
         }
+        if (resp?.token) localStorage.setItem("rf_token", resp.token);
       } catch {}
     })();
   }, []);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -30,9 +30,15 @@ export async function api<T>(path: string, method: HttpMethod = "GET", body?: un
   }
 
   try {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (!isServer) {
+      const token = localStorage.getItem("rf_token");
+      if (token) headers["Authorization"] = `Bearer ${token}`;
+    }
+
     const res = await fetch(url, {
       method,
-      headers: { "Content-Type": "application/json" },
+      headers,
       body: body ? JSON.stringify(body) : undefined,
       cache: "no-store",
       credentials: "include",

--- a/frontend/src/lib/campaignContext.ts
+++ b/frontend/src/lib/campaignContext.ts
@@ -1,3 +1,9 @@
+export type Dream100Context = {
+  positioning_level: "1" | "2" | "3" | "";
+  career_result: string;
+  free_deliverable: string;
+};
+
 export type RFCampaignContextV1 = {
   version: 1;
   updated_at: string;
@@ -23,6 +29,7 @@ export type RFCampaignContextV1 = {
   contact_research?: any;
   selected_contact_signals?: any[];
   selected_company_signals?: any[];
+  dream100?: Dream100Context;
   links?: {
     bio_page_url?: string;
     work_link?: string;
@@ -146,6 +153,16 @@ export function buildCampaignContextV1(contactId: string): RFCampaignContextV1 {
   const contactResearchByContact = safeJson<Record<string, any>>(lsGet("context_research_by_contact"), {});
   const contactResearch = cid && contactResearchByContact ? contactResearchByContact[cid] : null;
 
+  const d100Raw = safeJson<any>(lsGet("rf_dream100"), null);
+  const dream100: Dream100Context | undefined =
+    d100Raw && (d100Raw.positioningLevel || d100Raw.careerResult || d100Raw.freeDeliverable)
+      ? {
+          positioning_level: d100Raw.positioningLevel || "",
+          career_result: d100Raw.careerResult || "",
+          free_deliverable: d100Raw.freeDeliverable || "",
+        }
+      : undefined;
+
   const bioPageUrl = String(lsGet("bio_page_url") || "").trim();
 
   const links = {
@@ -175,6 +192,7 @@ export function buildCampaignContextV1(contactId: string): RFCampaignContextV1 {
     contact_research: contactResearch,
     selected_contact_signals: safeJson<any[]>(lsGet("rf_selected_contact_signals"), []),
     selected_company_signals: safeJson<any[]>(lsGet("rf_selected_company_signals"), []),
+    dream100,
     links,
   };
 }


### PR DESCRIPTION
## Summary
- Fix gap analysis localStorage key mismatch so campaign context receives gap data (was silently empty on every campaign)
- Add dream100_brief to context_research LLM output (best_hook, company_summary, team_function_context, pain_points, tone_style, recent_news_highlight, outreach_angle)
- campaign.py _build_research_brief now prefers dream100_brief.best_hook as top-priority contact signal
- Apply Dream 100 methodology to campaign steps 2 and 3 (exact one-sentence templates) and step 4 (gracious-close LLM prompt)
- Fix defaultInstructions for all 4 email steps to match Dream 100 sequence
- Update step labels: Day 1 Initial Outreach, Day 3 Follow-Up, Day 7 Final Follow-Up, Breakup / Close
- Surface dream100_brief card in Decision Makers UI (Best Hook, Pain Points, Tone/Style, Outreach Angle)

## Files changed
- backend/app/routers/campaign.py
- backend/app/routers/context_research.py
- frontend/src/app/campaign/CampaignV2.tsx
- frontend/src/app/find-contact/page.tsx
- frontend/src/app/gap-analysis/page.tsx
- frontend/src/lib/campaignContext.ts

Made with [Cursor](https://cursor.com)