### PR TITLE
feat: bio page dream100 integration and subject line A/B variants

### DIFF
--- a/backend/app/routers/bio_pages.py
+++ b/backend/app/routers/bio_pages.py
@@ -171,6 +171,7 @@ class GenerateBioPageRequest(BaseModel):
     offer_draft: Optional[Dict[str, Any]] = None
     profile_image_url: Optional[str] = None
     theme: Optional[BioPageTheme] = None
+    dream100: Optional[Dict[str, Any]] = None
 
 
 class GenerateBioPageResponse(BaseModel):
@@ -318,6 +319,11 @@ async def generate_bio_page(payload: GenerateBioPageRequest, http_request: Reque
                     for k in ["company", "company_name", "employer", "org", "organization"]:
                         if k in selected_job:
                             selected_job[k] = ""
+                d100 = payload.dream100 or {}
+                d100_career_result = str(d100.get("careerResult") or "").strip()
+                d100_deliverable = str(d100.get("freeDeliverable") or "").strip()
+                d100_level = str(d100.get("positioningLevel") or "").strip()
+
                 prompt = {
                     "display_name": deterministic.display_name,
                     "selected_job": selected_job,
@@ -331,6 +337,12 @@ async def generate_bio_page(payload: GenerateBioPageRequest, http_request: Reque
                         "output_json_only": True,
                     },
                 }
+                if d100_career_result:
+                    prompt["dream100"] = {
+                        "career_result": d100_career_result,
+                        "free_deliverable": d100_deliverable,
+                        "positioning_level": d100_level,
+                    }
                 messages = [
                     {
                         "role": "system",
@@ -343,7 +355,15 @@ async def generate_bio_page(payload: GenerateBioPageRequest, http_request: Reque
                             "- Do NOT claim expertise/certification in any tool, framework, or standard unless it appears in resume_extract.\n"
                             "- Do NOT use the word 'expert' or 'expertise'.\n"
                             "- If resume_extract does not include NIST standards, do NOT mention NIST 800-53 / NIST 800-171.\n"
-                            "Return ONLY valid JSON with keys:\n"
+                            + (
+                                f"Dream 100 context: the candidate's strongest result is '{d100_career_result}'. "
+                                + (f"Their free deliverable offer: '{d100_deliverable}'. " if d100_deliverable else "")
+                                + "The headline and first proof_point MUST incorporate this result. "
+                                "Make the headline reflect their strongest achievement or category leadership. "
+                                "Do NOT say 'expert' or 'seasoned'. Use the result itself as the proof.\n"
+                                if d100_career_result else ""
+                            )
+                            + "Return ONLY valid JSON with keys:\n"
                             "- headline: string\n"
                             "- subheadline: string\n"
                             "- proof_points: array of 3-6 strings (short, punchy)\n"

--- a/backend/app/routers/campaign.py
+++ b/backend/app/routers/campaign.py
@@ -1457,7 +1457,9 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
                 "  - body: 2-4 sentences max. Even more casual than the email. Same hook, same deliverable, same CTA.\n\n"
                 "voice_note: Loom/voice note script\n"
                 "  - script: 30-45 second spoken script. Open with hook. Explain deliverable in one sentence. End with CTA. Write exactly how you'd say it out loud — no formal language.\n\n"
-                "Return ONLY valid JSON: { \"email\": { \"subject\": \"...\", \"body\": \"...\" }, \"dm\": { \"body\": \"...\" }, \"voice_note\": { \"script\": \"...\" } }\n"
+                "Return ONLY valid JSON:\n"
+                "{ \"email\": { \"subject\": \"...\", \"body\": \"...\", \"subject_alt_1\": \"...\", \"subject_alt_2\": \"...\" }, \"dm\": { \"body\": \"...\" }, \"voice_note\": { \"script\": \"...\" } }\n"
+                "subject_alt_1 and subject_alt_2: two MORE subject line options (different angles — curiosity, specificity, directness). All subjects must be lowercase 2-5 words.\n"
             )
 
             d100_messages = [
@@ -1489,6 +1491,8 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
             d100_email_body = str(email_v.get("body") or "").strip()
             d100_dm_body = str(dm_v.get("body") or "").strip()
             d100_voice_script = str(voice_v.get("script") or "").strip()
+            d100_subject_alt_1 = _normalize_message_text(_no_em_dashes(str(email_v.get("subject_alt_1") or "").strip().lower()))[:100]
+            d100_subject_alt_2 = _normalize_message_text(_no_em_dashes(str(email_v.get("subject_alt_2") or "").strip().lower()))[:100]
 
             d100_email_body = _normalize_message_text(_no_em_dashes(
                 _append_signature(_strip_existing_signature(_strip_fluff_openers(d100_email_body)))
@@ -1520,7 +1524,7 @@ async def generate_campaign_step(payload: CampaignGenerateStepRequest, http_requ
                     "dream100_mode": True,
                     "positioning_level": positioning_level,
                     "dream100_variants": {
-                        "email": {"subject": d100_subject, "body": d100_email_body},
+                        "email": {"subject": d100_subject, "body": d100_email_body, "subject_alt_1": d100_subject_alt_1, "subject_alt_2": d100_subject_alt_2},
                         "dm": {"body": d100_dm_body},
                         "voice_note": {"script": d100_voice_script},
                     },

--- a/frontend/src/app/bio-page/page.tsx
+++ b/frontend/src/app/bio-page/page.tsx
@@ -489,11 +489,16 @@ export default function BioPageStep() {
     setBusy("generate");
     setMsg(null);
     try {
+      const dream100Raw = typeof window !== "undefined" ? localStorage.getItem("rf_dream100") : null;
+      let dream100: any = null;
+      try { dream100 = dream100Raw ? JSON.parse(dream100Raw) : null; } catch {}
+
       const res = await api<{ draft: BioPageDraft }>("/bio-pages/generate", "POST", {
         resume_extract: resumeExtract,
         selected_job_description: selectedJob,
         painpoint_matches: Array.isArray(painpointMatches) ? painpointMatches : [],
         offer_draft: offerDraft,
+        dream100: dream100 || undefined,
       });
       if (res?.draft) {
         // Preserve user-entered URLs across regenerations.

--- a/frontend/src/app/campaign/CampaignV2.tsx
+++ b/frontend/src/app/campaign/CampaignV2.tsx
@@ -38,7 +38,7 @@ type Mode = "job-seeker" | "recruiter";
 type Dream100VariantTab = "email" | "dm" | "voice_note";
 
 type Dream100Variants = {
-  email: { subject: string; body: string };
+  email: { subject: string; body: string; subject_alt_1?: string; subject_alt_2?: string };
   dm: { body: string };
   voice_note: { script: string };
 };
@@ -1074,13 +1074,31 @@ export default function CampaignV2() {
 
                 {activeTab !== "voice_note" && (
                   <div>
-                    <div className="text-xs font-semibold text-white/70 uppercase tracking-wider mb-1">Subject</div>
+                    <div className="flex items-center justify-between mb-1">
+                      <div className="text-xs font-semibold text-white/70 uppercase tracking-wider">Subject</div>
+                      {step.subject && <CopyButton text={String(step.subject || "")} />}
+                    </div>
                     <input
                       value={String(step.subject || "")}
                       onChange={(e) => updateStep(cid, step.id, { subject: e.target.value })}
                       className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
                       placeholder={activeTab === "dm" ? "No subject for DMs" : "Generate to fill..."}
                     />
+                    {activeTab === "email" && (d100Variants.email.subject_alt_1 || d100Variants.email.subject_alt_2) && (
+                      <div className="mt-2 space-y-1">
+                        <div className="text-[10px] text-white/40 uppercase tracking-wider">A/B alternatives — click to use:</div>
+                        {[d100Variants.email.subject_alt_1, d100Variants.email.subject_alt_2].filter(Boolean).map((alt, i) => (
+                          <button
+                            key={i}
+                            type="button"
+                            onClick={() => updateStep(cid, step.id, { subject: cleanMessageText(alt!) })}
+                            className="w-full text-left text-xs text-white/70 border border-white/10 bg-white/5 hover:bg-blue-600/20 hover:border-blue-400/30 rounded px-2.5 py-1.5 transition-colors"
+                          >
+                            {alt}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                   </div>
                 )}
                 <div>


### PR DESCRIPTION
## Summary
- Bio page backend: GenerateBioPageRequest now accepts dream100 context; LLM system prompt injects career_result so headline and first proof_point anchor to the candidate's strongest career result rather than generic role-fit language
- Bio page frontend: reads rf_dream100 from localStorage and sends it on every generate call
- Campaign step 1: LLM generates subject_alt_1 and subject_alt_2 as alternative subject line angles (curiosity / specificity / directness)
- CampaignV2: renders alt subjects as clickable pills under the subject field — click to swap to that subject line
- Added copy button to subject line field in Dream 100 email tab

## Files changed
- backend/app/routers/bio_pages.py
- frontend/src/app/bio-page/page.tsx
- backend/app/routers/campaign.py
- frontend/src/app/campaign/CampaignV2.tsx