### PR TITLE
feat: Week 26 route system, Dream 100 targeting, and field moves

### DIFF
--- a/backend/app/routers/job_preferences.py
+++ b/backend/app/routers/job_preferences.py
@@ -135,6 +135,81 @@ async def suggest_deliverables(payload: SuggestDeliverablesRequest):
         ])
 
 
+class Dream100PositioningInput(BaseModel):
+    positioning_level: Optional[str] = None
+    career_result: Optional[str] = None
+    free_deliverable: Optional[str] = None
+
+
+class Dream100TargetingRequest(BaseModel):
+    preferences: JobPreferences
+    dream100: Optional[Dream100PositioningInput] = None
+    resume_extract: Optional[Dict[str, Any]] = None
+
+
+class IdealCompanyCriteria(BaseModel):
+    headcount: str = ""
+    growth_signals: List[str] = []
+    funding_stage: str = ""
+    tech_stack_clues: List[str] = []
+    content_activity: str = ""
+    summary: str = ""
+
+
+class ActiveNeedSignal(BaseModel):
+    signal: str
+    why_it_matters: str = ""
+
+
+class RedFlag(BaseModel):
+    flag: str
+    disqualify_reason: str = ""
+
+
+class ChannelPlaybookItem(BaseModel):
+    channel: str
+    how_to: List[str] = []
+    example_search: str = ""
+    url: str = ""
+
+
+class ScoringFactor(BaseModel):
+    factor: str
+    weight: str = "medium"
+    score_guide: str = ""
+
+
+class ScoringRubric(BaseModel):
+    overview: str = ""
+    factors: List[ScoringFactor] = []
+    how_to_use: str = ""
+
+
+class SampleTarget(BaseModel):
+    company_type: str
+    team_structure: str = ""
+    why_fit: str = ""
+    where_to_find_contact: str = ""
+    hook_angle: str = ""
+    example_score: int = 7
+
+
+class Dream100TargetingData(BaseModel):
+    ideal_company: IdealCompanyCriteria
+    active_need_signals: List[ActiveNeedSignal] = []
+    red_flags: List[RedFlag] = []
+    channel_playbook: List[ChannelPlaybookItem] = []
+    scoring_rubric: ScoringRubric
+    sample_targets: List[SampleTarget] = []
+
+
+class Dream100TargetingResponse(BaseModel):
+    success: bool
+    message: str
+    targeting: Dream100TargetingData
+    used_llm: bool = False
+
+
 class GreenhouseBoardsResponse(BaseModel):
     success: bool
     message: str
@@ -283,6 +358,334 @@ def _indeed_query(p: JobPreferences) -> str:
 
     # Keep short (indeed behaves better)
     return " ".join(q.split())[:60]
+
+
+def _build_boolean_search_strings(p: JobPreferences) -> Dict[str, str]:
+    """Pre-built Boolean strings for job board channels."""
+    role = _role_keyword_from_categories(p.role_categories or []) or "manager"
+    skill = next((str(s).strip() for s in (p.skills or []) if str(s).strip()), "")
+    industry = next((str(x).strip() for x in (p.industries or []) if str(x).strip()), "")
+    skill_part = f' OR "{skill}"' if skill else ""
+    ind_part = f' AND "{industry}"' if industry else ""
+    return {
+        "linkedin_jobs": f'("{role}" OR "lead {role}" OR "senior {role}"){skill_part}{ind_part}',
+        "indeed": f"{role} {skill}".strip()[:60],
+        "greenhouse_lever": f'site:boards.greenhouse.io OR site:jobs.lever.co "{role}" {skill}'.strip(),
+        "adjacent_roles": f'("{role}" OR "director" OR "head of") AND (hiring OR "we are looking"){ind_part}',
+    }
+
+
+def _channel_playbook_seed(p: JobPreferences) -> List[Dict[str, Any]]:
+    """Deterministic channel playbook with real URLs where possible."""
+    booleans = _build_boolean_search_strings(p)
+    q = quote_plus(_board_query(p, max_len=60))
+    role = _role_keyword_from_categories(p.role_categories or []) or "your function"
+    industries = ", ".join((p.industries or [])[:2]) or "your target industry"
+    return [
+        {
+            "channel": "LinkedIn",
+            "how_to": [
+                "Search company pages in your target size/industry and follow hiring managers who post about team growth",
+                "Use LinkedIn Jobs with your Boolean string, then click through to company pages of adjacent-role postings",
+                "Check 'People also viewed' on profiles of hiring managers in similar companies",
+                "Engage with recent posts (comment thoughtfully) before sending a connection request or DM",
+            ],
+            "example_search": booleans["linkedin_jobs"],
+            "url": _linkedin_url(p),
+        },
+        {
+            "channel": "Job boards (Boolean search)",
+            "how_to": [
+                f'LinkedIn Jobs Boolean: {booleans["linkedin_jobs"]}',
+                f'Indeed search: {booleans["indeed"]}',
+                f'Greenhouse/Lever discovery: {booleans["greenhouse_lever"]}',
+                "Look for adjacent titles (not your exact title) — companies hiring related roles often need your function next",
+            ],
+            "example_search": booleans["adjacent_roles"],
+            "url": f"https://www.indeed.com/jobs?q={quote_plus(booleans['indeed'])}",
+        },
+        {
+            "channel": "Twitter / X",
+            "how_to": [
+                f'Search: "{role}" hiring OR "we\'re hiring" OR "join our team" + industry keywords',
+                "Follow founders and operators who announce headcount milestones or product launches",
+                "Reply to tweets about team building — warm engagement before cold outreach",
+            ],
+            "example_search": f'"{role}" (hiring OR "we are hiring") {industries}',
+            "url": f"https://x.com/search?q={quote_plus(role + ' hiring')}&f=live",
+        },
+        {
+            "channel": "Podcasts",
+            "how_to": [
+                f'Search Listen Notes or Apple Podcasts for "{role}" + "{industries}"',
+                "Target founders/operators who've discussed building teams in your function",
+                "Reference a specific episode moment in your outreach hook",
+            ],
+            "example_search": f"{role} {industries} podcast",
+            "url": f"https://www.listennotes.com/search/?q={quote_plus(role + ' ' + industries)}",
+        },
+        {
+            "channel": "Newsletters / Substacks",
+            "how_to": [
+                f'Search Substack Discover for writers in {industries} covering {role} topics',
+                "Authors often run or advise at target companies — check their bio and linked companies",
+                "Subscribe and engage before reaching out; reference a specific newsletter issue",
+            ],
+            "example_search": f"{industries} {role} substack",
+            "url": f"https://substack.com/search/{quote_plus(industries + ' ' + role)}",
+        },
+        {
+            "channel": "Communities (Slack / Discord)",
+            "how_to": [
+                f'Search for Slack communities in {industries} (e.g. via Slofile, Google "{industries} slack community")',
+                "Join operator/founder communities where hiring managers ask for referrals",
+                "Contribute value in channels before pitching — lurk first, then offer your deliverable",
+            ],
+            "example_search": f"{industries} slack community {role}",
+            "url": "",
+        },
+        {
+            "channel": "Crunchbase / funding announcements",
+            "how_to": [
+                "Filter Crunchbase for companies that raised in the last 6-12 months in your target industries",
+                "Series A/B companies typically hire your function within 3-6 months of a raise",
+                "Cross-reference funding news on TechCrunch with LinkedIn headcount growth signals",
+            ],
+            "example_search": f"{industries} funding 2025 2026",
+            "url": f"https://www.crunchbase.com/discover/organization.companies/{quote_plus(industries)}",
+        },
+    ]
+
+
+def _deterministic_dream100_targeting(p: JobPreferences, d100: Optional[Dream100PositioningInput]) -> Dream100TargetingData:
+    """Fallback targeting plan when LLM is unavailable."""
+    career = str((d100.career_result if d100 else "") or "").strip()
+    deliverable = str((d100.free_deliverable if d100 else "") or "").strip()
+    role = _role_keyword_from_categories(p.role_categories or []) or "your target role"
+    sizes = ", ".join(p.company_size[:2]) if p.company_size else "50-500 employees"
+    industries = ", ".join(p.industries[:3]) if p.industries else "your target industries"
+    skills = ", ".join(p.skills[:4]) if p.skills else "your core skills"
+
+    ideal = IdealCompanyCriteria(
+        headcount=sizes,
+        growth_signals=[
+            "Headcount growing 10%+ in the last 12 months (check LinkedIn company page)",
+            "Recent funding round or revenue milestone announced in the last 18 months",
+            "Active job postings for adjacent roles (signals budget and hiring intent)",
+        ],
+        funding_stage="Series A through growth-stage (post-PMF, pre-IPO) unless you prefer enterprise",
+        tech_stack_clues=[f"Uses tools/skills aligned with: {skills}"] if skills else ["Match stack to your resume skills"],
+        content_activity="Founders or hiring managers posting weekly about product, team, or growth challenges",
+        summary=f"Mid-market companies in {industries} that are scaling {role} capacity and show public hiring or growth signals.",
+    )
+
+    signals = [
+        ActiveNeedSignal(
+            signal="Multiple open roles in your function or adjacent functions",
+            why_it_matters="Budget is allocated and hiring is active — not a cold guess",
+        ),
+        ActiveNeedSignal(
+            signal="Recent funding, product launch, or geographic expansion",
+            why_it_matters="Growth creates new pain points your background can address immediately",
+        ),
+        ActiveNeedSignal(
+            signal="Hiring manager posting about team challenges, process gaps, or scaling pains",
+            why_it_matters="Public pain = a ready-made hook for your deliverable offer",
+        ),
+        ActiveNeedSignal(
+            signal="Company content mentions metrics or outcomes you have directly improved",
+            why_it_matters="Your career result maps cleanly to their stated priorities",
+        ),
+    ]
+
+    red_flags = [
+        RedFlag(flag="Hiring freeze or recent layoffs with no growth counter-signals", disqualify_reason="No budget or appetite to hire your function right now"),
+        RedFlag(flag="No identifiable decision maker reachable on LinkedIn or email", disqualify_reason="Dream 100 requires a person, not a black hole careers page"),
+        RedFlag(flag="Your strongest result does not connect to any visible company pain", disqualify_reason="Outreach will feel generic and get ignored"),
+    ]
+
+    playbook_raw = _channel_playbook_seed(p)
+    playbook = [ChannelPlaybookItem(**item) for item in playbook_raw]
+
+    rubric = ScoringRubric(
+        overview="Score each company 1-10 before adding to your Dream 100 list. Pursue 8+, maybe 5-7, skip below 5.",
+        factors=[
+            ScoringFactor(factor="Growth stage & hiring intent", weight="high", score_guide="1=frozen/shrinking, 10=actively hiring your function with budget signals"),
+            ScoringFactor(factor="Likelihood of needing your function", weight="high", score_guide="1=no visible pain, 10=multiple adjacent roles open + public scaling challenges"),
+            ScoringFactor(factor="Publicly visible pain points", weight="high", score_guide="1=generic company page only, 10=specific posts/news about problems you solve"),
+            ScoringFactor(factor="Reachable hiring manager quality", weight="medium", score_guide="1=no LinkedIn presence, 10=active poster with clear title and email findable"),
+            ScoringFactor(factor="Career result fit", weight="high", score_guide=f"1=no connection to their challenges, 10=your result ({career[:60] or 'your track record'}) directly maps to their stated priority"),
+        ],
+        how_to_use="Research each company for 10 minutes, score on all 5 factors, average or weight toward high factors. Only add 8+ to your active Dream 100 list.",
+    )
+
+    hook_base = deliverable or "a tailored deliverable for their team"
+    career_hook = career or "relevant track record in this space"
+    samples = [
+        SampleTarget(
+            company_type=f"Series B {industries.split(',')[0].strip() if industries else 'SaaS'} company scaling {role}",
+            team_structure=f"50-200 employees, first dedicated {role} hire or small team of 2-3",
+            why_fit=f"They need someone who can {career_hook} without a long ramp",
+            where_to_find_contact="VP/Director on LinkedIn who posted about team growth or hiring",
+            hook_angle=f"Saw you're scaling the team — put together {hook_base}. Mind if I send it?",
+            example_score=9,
+        ),
+        SampleTarget(
+            company_type=f"Growth-stage company post-funding in {industries}",
+            team_structure="200-500 employees, building out a new function or replacing a departed leader",
+            why_fit="Funding creates urgency; they need proven operators not learners",
+            where_to_find_contact="Head of function + founder on LinkedIn; check Crunchbase for recent raise",
+            hook_angle=f"Congrats on the raise — noticed you're hiring adjacent roles. I {career_hook}. Worth a quick look at {hook_base}?",
+            example_score=8,
+        ),
+        SampleTarget(
+            company_type=f"Mid-market {industries} company with visible process/ops pain",
+            team_structure="100-300 employees, lean team overwhelmed by growth",
+            why_fit="Public content mentions challenges your deliverable directly addresses",
+            where_to_find_contact="Hiring manager who commented on industry posts in the last 30 days",
+            hook_angle=f"Your post about [specific challenge] resonated — I built {hook_base} for teams in exactly this situation.",
+            example_score=8,
+        ),
+    ]
+    # Pad to 10 with varied archetypes
+    extras = [
+        ("Enterprise division launching new product line", "500-2000 employees, internal startup team", 7),
+        ("Agency/consultancy adding a practice area", "20-100 employees, partner-led hiring", 6),
+        ("PE-backed rollup consolidating operations", "Multi-site, new COO/VP mandate", 8),
+        ("Remote-first startup hiring US leadership", "30-80 employees, founder still hands-on", 7),
+        ("Company replacing a departed leader (backfill)", "Stable headcount, urgent backfill posting", 9),
+        ("Stealth startup coming out of beta", "10-30 employees, first GTM or ops hire", 6),
+        ("Nonprofit or mission org scaling impact", "50-150 employees, grant-funded growth", 5),
+    ]
+    for i, (ctype, team, score) in enumerate(extras):
+        if len(samples) >= 10:
+            break
+        samples.append(SampleTarget(
+            company_type=ctype,
+            team_structure=team,
+            why_fit=f"Your background in {role} maps to their scaling moment",
+            where_to_find_contact="LinkedIn search + job board adjacent-role discovery",
+            hook_angle=f"I put together {hook_base} — relevant given where you are in the growth curve.",
+            example_score=score,
+        ))
+
+    return Dream100TargetingData(
+        ideal_company=ideal,
+        active_need_signals=signals,
+        red_flags=red_flags,
+        channel_playbook=playbook,
+        scoring_rubric=rubric,
+        sample_targets=samples[:10],
+    )
+
+
+@router.post("/dream100-targeting", response_model=Dream100TargetingResponse)
+async def generate_dream100_targeting(payload: Dream100TargetingRequest):
+    """
+    Generate a full Dream 100 targeting plan: ideal company criteria, active-need signals,
+    red flags, channel playbook, 1-10 scoring rubric, and 10 sample target archetypes.
+    """
+    p = payload.preferences
+    d100 = payload.dream100
+    fallback = _deterministic_dream100_targeting(p, d100)
+    client = get_openai_client()
+
+    resume = payload.resume_extract or {}
+    resume_summary = ""
+    if isinstance(resume, dict):
+        positions = resume.get("positions") or []
+        if positions and isinstance(positions[0], dict):
+            resume_summary = f"{positions[0].get('title', '')} at {positions[0].get('company', '')}"
+        metrics = resume.get("key_metrics") or []
+        if metrics:
+            resume_summary += "; metrics: " + ", ".join(
+                str(m.get("metric", "")) for m in metrics[:3] if isinstance(m, dict)
+            )
+
+    ctx = {
+        "preferences": p.model_dump(),
+        "dream100": (d100.model_dump() if d100 else {}),
+        "resume_summary": resume_summary,
+        "search_urls": {
+            "linkedin_jobs": _linkedin_url(p),
+            "indeed": f"https://www.indeed.com/jobs?q={quote_plus(_indeed_query(p))}",
+        },
+        "boolean_searches": _build_boolean_search_strings(p),
+        "channel_playbook_seed": _channel_playbook_seed(p),
+    }
+
+    system = (
+        "You are a Dream 100 job search strategist. Build a personalized targeting plan for this candidate.\n"
+        "Use ONLY the provided context. Be specific to their role categories, industries, skills, company size prefs, and career result.\n"
+        "Return ONLY valid JSON with this exact structure:\n"
+        "{\n"
+        '  "ideal_company": {\n'
+        '    "headcount": "string", "growth_signals": ["..."], "funding_stage": "string",\n'
+        '    "tech_stack_clues": ["..."], "content_activity": "string", "summary": "string"\n'
+        "  },\n"
+        '  "active_need_signals": [{"signal": "string", "why_it_matters": "string"}],\n'
+        '  "red_flags": [{"flag": "string", "disqualify_reason": "string"}],\n'
+        '  "channel_playbook": [{"channel": "string", "how_to": ["step1","step2"], "example_search": "string", "url": "string"}],\n'
+        '  "scoring_rubric": {\n'
+        '    "overview": "string",\n'
+        '    "factors": [{"factor": "string", "weight": "high|medium|low", "score_guide": "what 1 vs 10 looks like"}],\n'
+        '    "how_to_use": "string"\n'
+        "  },\n"
+        '  "sample_targets": [{\n'
+        '    "company_type": "string", "team_structure": "string", "why_fit": "string",\n'
+        '    "where_to_find_contact": "string", "hook_angle": "string", "example_score": 7\n'
+        "  }]\n"
+        "}\n\n"
+        "Requirements:\n"
+        "- ideal_company: tailored to their preferences (size, industries, skills)\n"
+        "- active_need_signals: exactly 4 signals that mean ACTIVELY IN NEED vs waste of time\n"
+        "- red_flags: exactly 3 immediate disqualifiers\n"
+        "- channel_playbook: exactly 7 channels — LinkedIn, Job boards (Boolean search), Twitter/X, Podcasts, Newsletters/Substacks, Communities (Slack/Discord), Crunchbase/funding announcements. Include concrete example_search strings and url where applicable. Merge/improve the channel_playbook_seed from context.\n"
+        "- scoring_rubric: 5 factors including growth stage, likelihood of needing their function, visible pain points, hiring manager reachability, career result fit. Score guide must explain 1 vs 10 for each.\n"
+        "- sample_targets: exactly 10 varied company archetypes (realistic types, not fake company names). Each needs hook_angle using their deliverable if provided.\n"
+    )
+
+    try:
+        if client.should_use_real_llm:
+            raw = client.run_chat_completion(
+                [{"role": "system", "content": system}, {"role": "user", "content": json.dumps(ctx, ensure_ascii=False)}],
+                temperature=0.35,
+                max_tokens=3500,
+                stub_json=fallback.model_dump(),
+            )
+            choices = raw.get("choices") or []
+            msg = (choices[0].get("message") if choices else {}) or {}
+            data = extract_json_from_text(str(msg.get("content") or "")) or {}
+            if data.get("ideal_company") and data.get("sample_targets"):
+                targeting = Dream100TargetingData(**data)
+                # Ensure playbook URLs from seed if LLM omitted them
+                seed_by_channel = {x["channel"]: x for x in _channel_playbook_seed(p)}
+                merged_playbook = []
+                for item in targeting.channel_playbook:
+                    seed = seed_by_channel.get(item.channel) or {}
+                    merged_playbook.append(ChannelPlaybookItem(
+                        channel=item.channel,
+                        how_to=item.how_to or seed.get("how_to", []),
+                        example_search=item.example_search or seed.get("example_search", ""),
+                        url=item.url or seed.get("url", ""),
+                    ))
+                if merged_playbook:
+                    targeting.channel_playbook = merged_playbook
+                return Dream100TargetingResponse(
+                    success=True,
+                    message="Dream 100 targeting plan generated",
+                    targeting=targeting,
+                    used_llm=True,
+                )
+    except Exception as exc:
+        logger.warning("Dream 100 targeting LLM failed: %s", exc)
+
+    return Dream100TargetingResponse(
+        success=True,
+        message="Dream 100 targeting plan generated (fallback)",
+        targeting=fallback,
+        used_llm=False,
+    )
 
 
 def _location_hint(p: JobPreferences) -> str:

--- a/frontend/src/app/gap-analysis/page.tsx
+++ b/frontend/src/app/gap-analysis/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useRouteGuard } from "@/lib/useRouteGuard";
 import { api } from "@/lib/api";
 import { formatCompanyName } from "@/lib/format";
 import InlineSpinner from "@/components/InlineSpinner";
@@ -167,6 +168,7 @@ function gapTierBadge(totalGaps: number) {
 
 export default function GapAnalysisPage() {
   const router = useRouter();
+  useRouteGuard(5);
   const [jobDescriptions, setJobDescriptions] = useState<JobDescription[]>([]);
   const [preferences, setPreferences] = useState<JobPreferences | null>(null);
   const [resumeExtract, setResumeExtract] = useState<ResumeExtract | null>(null);

--- a/frontend/src/app/job-descriptions/page.tsx
+++ b/frontend/src/app/job-descriptions/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useRouteGuard } from "@/lib/useRouteGuard";
 import { api } from "@/lib/api";
 import { formatCompanyName } from "@/lib/format";
 import InlineSpinner from "@/components/InlineSpinner";
@@ -256,6 +257,7 @@ function analyzeIndeedUrl(raw: string): {
 
 export default function JobDescriptionsPage() {
   const router = useRouter();
+  useRouteGuard(4);
   const AUTO_POS_KW_KEY = "rf_auto_roles_positive_keywords_v1";
   const AUTO_NEG_KW_KEY = "rf_auto_roles_negative_keywords_v1";
   // Important: avoid reading localStorage during the initial render to prevent

--- a/frontend/src/app/job-preferences/page.tsx
+++ b/frontend/src/app/job-preferences/page.tsx
@@ -4,11 +4,30 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { api } from "@/lib/api";
 import CollapsibleSection from "@/components/CollapsibleSection";
+import Dream100TargetingPanel, { type Dream100Targeting } from "@/components/Dream100TargetingPanel";
+import WorkflowSummary from "@/components/WorkflowSummary";
+import Link from "next/link";
+import { getActiveRoute, ROUTE_DEFINITIONS } from "@/lib/workflowRoutes";
 
 interface Dream100Positioning {
   positioningLevel: "1" | "2" | "3" | "";
-  careerResult: string;
-  freeDeliverable: string;
+}
+
+function validatePreferences(p: JobPreferences): string[] {
+  const errors: string[] = [];
+  if (!getActiveRoute()) errors.push("Choose a route on the Dashboard first");
+  if (!p.values?.length) errors.push("What do you value in a new role? needs at least one option");
+  if (!p.roleCategories?.length) errors.push("What kinds of roles are you interested in? needs at least one option");
+  if (!p.locationPreferences?.length) errors.push("Where would you like to work? needs at least one option");
+  if (!p.roleType?.length) errors.push("What type of roles are you looking for? needs at least one option");
+  if (!p.companySize?.length) errors.push("What is your ideal company size? needs at least one option");
+  if (!p.industries?.length) errors.push("What industries are exciting to you? needs at least one option");
+  if (!p.jobSearchStatus?.trim()) errors.push("What's the status of your role search? needs a selection");
+  const salaryDigits = String(p.minimumSalary || "").replace(/\D/g, "");
+  if (!salaryDigits) errors.push("Minimum expected salary needs a number");
+  const needsMetro = p.locationPreferences.some((l) => l === "In-Person" || l === "Hybrid");
+  if (needsMetro && !(p.metroAreas?.length)) errors.push("Nearest metropolitan area(s) needs at least one option");
+  return errors;
 }
 
 interface JobPreferences {
@@ -219,38 +238,15 @@ const US_METRO_AREAS = [
   "Washington, DC",
 ];
 
-const POSITIONING_LEVELS: { level: "1" | "2" | "3"; label: string; subtitle: string; strategy: string }[] = [
-  {
-    level: "1",
-    label: "Level 1 — Open Req",
-    subtitle: "They're actively hiring for your exact role",
-    strategy: "Direct CTA — apply and reach out with a specific hook",
-  },
-  {
-    level: "2",
-    label: "Level 2 — Need Exists",
-    subtitle: "They need someone like you but don't know it yet",
-    strategy: "Lead with a free insight or mini-deliverable",
-  },
-  {
-    level: "3",
-    label: "Level 3 — Hidden Market",
-    subtitle: "No open role — you're creating the need",
-    strategy: "Lead with substantial free work upfront",
-  },
-];
 
 export default function JobPreferencesPage() {
   const router = useRouter();
   const [mode, setMode] = useState<"job-seeker" | "recruiter">("job-seeker");
   const [isSaving, setIsSaving] = useState(false);
-  const [dream100, setDream100] = useState<Dream100Positioning>({
-    positioningLevel: "",
-    careerResult: "",
-    freeDeliverable: "",
-  });
-  const [deliverableSuggestions, setDeliverableSuggestions] = useState<string[]>([]);
-  const [isSuggestingDeliverables, setIsSuggestingDeliverables] = useState(false);
+  const [dream100, setDream100] = useState<Dream100Positioning>({ positioningLevel: "" });
+  const [dream100Targeting, setDream100Targeting] = useState<Dream100Targeting | null>(null);
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  const [activeRouteLabel, setActiveRouteLabel] = useState<string>("");
   const [preferences, setPreferences] = useState<JobPreferences>({
     values: [],
     roleCategories: [],
@@ -279,18 +275,27 @@ export default function JobPreferencesPage() {
     }
 
     try {
-      const d100 = localStorage.getItem("rf_dream100");
-      if (d100) {
-        const parsed = JSON.parse(d100);
-        setDream100({
-          positioningLevel: parsed?.positioningLevel || "",
-          careerResult: parsed?.careerResult || "",
-          freeDeliverable: parsed?.freeDeliverable || "",
-        });
+      const d100t = localStorage.getItem("rf_dream100_targeting");
+      if (d100t) {
+        setDream100Targeting(JSON.parse(d100t));
       }
     } catch {
       // ignore
     }
+
+    try {
+      const d100 = localStorage.getItem("rf_dream100");
+      if (d100) {
+        const parsed = JSON.parse(d100);
+        setDream100({ positioningLevel: parsed?.positioningLevel || parsed?.selectedRoute || "" });
+      }
+    } catch {
+      // ignore
+    }
+
+    const route = getActiveRoute();
+    const def = ROUTE_DEFINITIONS.find((r) => r.id === route);
+    setActiveRouteLabel(def ? `${def.badge}: ${def.title}` : "");
 
     try {
       const cached = localStorage.getItem("job_preferences");
@@ -406,36 +411,21 @@ export default function JobPreferencesPage() {
     setPreferences((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handleSuggestDeliverables = async () => {
-    if (isSuggestingDeliverables) return;
-    setIsSuggestingDeliverables(true);
-    setDeliverableSuggestions([]);
-    try {
-      const resp = await api.post("/job-preferences/suggest-deliverables", {
-        career_result: dream100.careerResult,
-        positioning_level: dream100.positioningLevel,
-        role_categories: preferences.roleCategories,
-        industries: preferences.industries,
-      });
-      if (resp?.suggestions?.length) {
-        setDeliverableSuggestions(resp.suggestions);
-      }
-    } catch {
-      setDeliverableSuggestions([
-        "A 30-60-90 day onboarding plan tailored to their open role",
-        "A short audit of their current process with 3 quick wins",
-        "A sample project or case study demonstrating your methodology",
-      ]);
-    } finally {
-      setIsSuggestingDeliverables(false);
-    }
-  };
-
   const handleSave = async () => {
     if (isSaving) return;
+    const errors = validatePreferences(preferences);
+    if (errors.length) {
+      setValidationErrors(errors);
+      setIsSaving(false);
+      return;
+    }
+    setValidationErrors([]);
     setIsSaving(true);
     localStorage.setItem("job_preferences", JSON.stringify(preferences));
     localStorage.setItem("rf_dream100", JSON.stringify(dream100));
+    if (dream100Targeting) {
+      localStorage.setItem("rf_dream100_targeting", JSON.stringify(dream100Targeting));
+    }
 
     try {
       const payload: BackendJobPreferences = {
@@ -493,99 +483,17 @@ export default function JobPreferencesPage() {
           </div>
 
           <div className="space-y-1">
-            {/* Dream 100 Positioning */}
-            <CollapsibleSection
-              title="Dream 100 Positioning"
-              count={dream100.positioningLevel ? 1 : 0}
-            >
-              <div className="space-y-6">
-                <div>
-                  <p className="text-sm text-white/70 mb-3">
-                    Most great jobs are never posted. Your positioning level determines how much free work you lead with and how you frame your outreach.
-                  </p>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-                    {POSITIONING_LEVELS.map(({ level, label, subtitle, strategy }) => {
-                      const selected = dream100.positioningLevel === level;
-                      return (
-                        <button
-                          key={level}
-                          type="button"
-                          onClick={() => setDream100((d) => ({ ...d, positioningLevel: level }))}
-                          className={`text-left rounded-lg border p-4 transition-all ${
-                            selected
-                              ? "border-blue-500 bg-blue-600/20 ring-1 ring-blue-500"
-                              : "border-white/10 bg-white/5 hover:border-white/30 hover:bg-white/10"
-                          }`}
-                        >
-                          <div className="font-semibold text-sm text-white mb-1">{label}</div>
-                          <div className="text-xs text-white/70 mb-2">{subtitle}</div>
-                          <div className={`text-xs font-medium ${selected ? "text-blue-300" : "text-white/40"}`}>
-                            → {strategy}
-                          </div>
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-white mb-1">
-                      Your strongest career result
-                    </label>
-                    <input
-                      type="text"
-                      value={dream100.careerResult}
-                      onChange={(e) => setDream100((d) => ({ ...d, careerResult: e.target.value }))}
-                      placeholder='e.g. "reduced CAC by 40% at X in 6 months"'
-                      className="w-full border border-white/20 rounded-md px-3 py-2 bg-white/5 text-white placeholder-white/30 text-sm focus:outline-none focus:border-blue-400"
-                    />
-                    <p className="mt-1 text-xs text-white/40">Lead with a number. This anchors every message you send.</p>
-                  </div>
-                  <div>
-                    <div className="flex items-center justify-between mb-1">
-                      <label className="block text-sm font-medium text-white">
-                        Your free deliverable idea
-                      </label>
-                      <button
-                        type="button"
-                        onClick={handleSuggestDeliverables}
-                        disabled={isSuggestingDeliverables || !dream100.careerResult.trim()}
-                        className="text-xs text-blue-300 hover:text-blue-200 border border-blue-500/30 rounded px-2 py-0.5 bg-blue-600/10 hover:bg-blue-600/20 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                      >
-                        {isSuggestingDeliverables ? "Generating..." : "Generate ideas"}
-                      </button>
-                    </div>
-                    <input
-                      type="text"
-                      value={dream100.freeDeliverable}
-                      onChange={(e) => setDream100((d) => ({ ...d, freeDeliverable: e.target.value }))}
-                      placeholder='e.g. "a teardown of their cold email sequence with 3 rewrites"'
-                      className="w-full border border-white/20 rounded-md px-3 py-2 bg-white/5 text-white placeholder-white/30 text-sm focus:outline-none focus:border-blue-400"
-                    />
-                    <p className="mt-1 text-xs text-white/40">What you offer upfront. The only ask in your first message is "mind if I send it?"</p>
-                    {deliverableSuggestions.length > 0 && (
-                      <div className="mt-2 space-y-1">
-                        <p className="text-xs text-white/50">Click a suggestion to use it:</p>
-                        {deliverableSuggestions.map((s, i) => (
-                          <button
-                            key={i}
-                            type="button"
-                            onClick={() => {
-                              setDream100((d) => ({ ...d, freeDeliverable: s }));
-                              setDeliverableSuggestions([]);
-                            }}
-                            className="w-full text-left text-xs text-white/80 border border-white/10 bg-white/5 hover:bg-blue-600/20 hover:border-blue-400/40 rounded px-2.5 py-1.5 transition-colors"
-                          >
-                            {s}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
+            <div className="mb-4 rounded-lg border border-blue-500/25 bg-blue-600/10 px-4 py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+              <div>
+                <div className="text-xs font-bold text-blue-300 uppercase tracking-wider">Active route</div>
+                <div className="text-sm text-white/85">
+                  {activeRouteLabel || "No route selected"}
                 </div>
               </div>
-            </CollapsibleSection>
+              <Link href="/" className="text-xs text-blue-300 hover:text-blue-200 underline shrink-0">
+                Change route on Dashboard
+              </Link>
+            </div>
 
             {/* Values */}
             <CollapsibleSection title={`What do you value in a ${mode === "job-seeker" ? "new role" : "client relationship"}?`} count={preferences.values.length}>
@@ -772,6 +680,19 @@ export default function JobPreferencesPage() {
               </div>
             </CollapsibleSection>
 
+            {/* Dream 100 Targeting — after role/industry prefs so generation has context */}
+            <CollapsibleSection
+              title="Dream 100 Targeting"
+              count={dream100Targeting ? 1 : 0}
+            >
+              <Dream100TargetingPanel
+                preferences={preferences}
+                dream100={dream100}
+                targeting={dream100Targeting}
+                onTargetingChange={setDream100Targeting}
+              />
+            </CollapsibleSection>
+
             {/* Minimum Salary */}
             <CollapsibleSection title="What is your minimum expected salary?">
               <input
@@ -840,6 +761,19 @@ export default function JobPreferencesPage() {
                   ))}
                 </ul>
               )}
+            </div>
+          )}
+
+          <WorkflowSummary />
+
+          {validationErrors.length > 0 && (
+            <div className="mt-4 rounded-lg border border-red-500/30 bg-red-500/10 p-3">
+              <p className="text-sm text-red-300 font-medium mb-1">Please complete the following:</p>
+              <ul className="text-xs text-red-200/90 space-y-1 list-disc list-inside">
+                {validationErrors.map((e) => (
+                  <li key={e}>{e}</li>
+                ))}
+              </ul>
             </div>
           )}
 

--- a/frontend/src/app/offer/page.tsx
+++ b/frontend/src/app/offer/page.tsx
@@ -4,7 +4,9 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { formatCompanyName } from "@/lib/format";
 import InlineSpinner from "@/components/InlineSpinner";
+import WorkflowSummary from "@/components/WorkflowSummary";
 import { api } from "@/lib/api";
+import { getActiveRoute } from "@/lib/workflowRoutes";
 
 type OfferCaseStudy = {
   title: string;
@@ -269,6 +271,11 @@ export default function OfferPage() {
   const [companySignals, setCompanySignals] = useState<any[]>([]);
   const [contactSignals, setContactSignals] = useState<any[]>([]);
   const [dream100, setDream100] = useState<any>(null);
+  const [freeDeliverable, setFreeDeliverable] = useState("");
+  const [caseStudyFocus, setCaseStudyFocus] = useState<{
+    caseIdx: number;
+    field: "problem" | "actions" | "impact";
+  } | null>(null);
 
   useEffect(() => {
     setResume(safeJson<any>(localStorage.getItem("resume_extract"), null));
@@ -279,6 +286,7 @@ export default function OfferPage() {
     setCompanySignals(safeJson<any[]>(localStorage.getItem("rf_selected_company_signals"), []));
     setContactSignals(safeJson<any[]>(localStorage.getItem("rf_selected_contact_signals"), []));
     setDream100(safeJson<any>(localStorage.getItem("rf_dream100"), null));
+    setFreeDeliverable(localStorage.getItem("rf_free_deliverable") || "");
   }, []);
 
   const activeRole = useMemo(() => {
@@ -549,8 +557,65 @@ export default function OfferPage() {
       out.push({ problem: "", actions: "", impact: clampLines(line, 120) });
     }
 
-    return out.slice(0, 6);
-  }, [resume]);
+    const m0 = roleSignals.match0;
+    if (m0?.painpoint_1) {
+      out.push({
+        problem: clampLines(String(m0.painpoint_1), 120),
+        actions: clampLines(String(m0.solution_1 || ""), 120),
+        impact: clampLines(String(m0.metric_1 || ""), 120),
+      });
+    }
+
+    for (const sig of companySignals.slice(0, 3)) {
+      const text = String(sig?.headline || sig?.text || sig?.signal || sig?.title || "").trim();
+      if (!text || text.length < 12) continue;
+      const key = `sig_${text.toLowerCase().slice(0, 40)}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ problem: clampLines(text, 120), actions: "", impact: "" });
+    }
+
+    return out.slice(0, 8);
+  }, [resume, roleSignals, companySignals]);
+
+  const suggestFreeDeliverable = () => {
+    const route = getActiveRoute();
+    const company = String(activeRole?.company || selectedRole?.company || "their team").trim();
+    const roleTitle = String(activeRole?.title || prefs?.roleCategories?.[0] || "your function").trim();
+    const signal = String(companySignals[0]?.headline || companySignals[0]?.text || companySignals[0]?.signal || "").trim();
+    if (route === "3") {
+      return `A free working prototype or audit for ${company} showing how ${roleTitle} could solve their top bottleneck`;
+    }
+    if (route === "2") {
+      return signal
+        ? `A free brief connecting "${clampLines(signal, 70)}" to a concrete fix for ${company}`
+        : `A free mini-audit for ${company} with 3 prioritized improvements`;
+    }
+    return `A free sample deliverable tailored to ${company}'s ${roleTitle} priorities`;
+  };
+
+  const insertCaseStudyField = (field: "problem" | "actions" | "impact", text: string) => {
+    const t = String(text || "").trim();
+    if (!t) return;
+    const caseIdx = caseStudyFocus?.caseIdx ?? 0;
+    setCaseStudies((prev) =>
+      prev.map((c, i) => (i === caseIdx ? { ...c, [field]: t } : c))
+    );
+  };
+
+  const caseStudyQuickInserts = useMemo(() => {
+    const groups: Record<"problem" | "actions" | "impact", Array<{ label: string; text: string }>> = {
+      problem: [],
+      actions: [],
+      impact: [],
+    };
+    for (const s of suggestedCaseStudies) {
+      if (s.problem) groups.problem.push({ label: clampLines(s.problem, 55), text: s.problem });
+      if (s.actions) groups.actions.push({ label: clampLines(s.actions, 55), text: s.actions });
+      if (s.impact) groups.impact.push({ label: clampLines(s.impact, 55), text: s.impact });
+    }
+    return groups;
+  }, [suggestedCaseStudies]);
 
   const addCredibility = (text: string) => {
     const t = String(text || "").trim();
@@ -562,6 +627,9 @@ export default function OfferPage() {
   const save = (next?: { goNext?: boolean }) => {
     setIsSaving(true);
     try {
+      if (freeDeliverable.trim()) {
+        localStorage.setItem("rf_free_deliverable", freeDeliverable.trim());
+      }
       if (activeRoleId) {
         const payload: OfferV1 = {
           version: 1,
@@ -814,6 +882,27 @@ export default function OfferPage() {
               </div>
             ) : null}
             {notice ? <div className="mt-2 text-[11px] text-emerald-200/90">{notice}</div> : null}
+          </div>
+
+          <div className="mb-6 rounded-lg border border-white/10 bg-black/20 p-4">
+            <div className="text-xs font-bold text-blue-300 uppercase tracking-wider mb-1">Free deliverable idea</div>
+            <p className="text-sm text-white/60 mb-3">
+              What you would offer for free to earn attention (especially Route 2 &amp; 3). Used in outreach and your bio.
+            </p>
+            <textarea
+              value={freeDeliverable}
+              onChange={(e) => setFreeDeliverable(e.target.value)}
+              rows={2}
+              className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder='e.g., "A free 2-page audit of their onboarding funnel with 3 fixes"'
+            />
+            <button
+              type="button"
+              onClick={() => setFreeDeliverable(suggestFreeDeliverable())}
+              className="mt-2 text-xs text-blue-300 hover:text-blue-200 underline"
+            >
+              Suggest from route + research
+            </button>
           </div>
 
           {/* Section heading */}
@@ -1086,18 +1175,21 @@ export default function OfferPage() {
                                   <input
                                     value={c.problem}
                                     onChange={(e) => setCaseStudies((prev) => prev.map((x, i) => (i === idx ? { ...x, problem: e.target.value } : x)))}
+                                    onFocus={() => setCaseStudyFocus({ caseIdx: idx, field: "problem" })}
                                     className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
                                     placeholder="Problem (what was broken?)"
                                   />
                                   <input
                                     value={c.actions}
                                     onChange={(e) => setCaseStudies((prev) => prev.map((x, i) => (i === idx ? { ...x, actions: e.target.value } : x)))}
+                                    onFocus={() => setCaseStudyFocus({ caseIdx: idx, field: "actions" })}
                                     className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
                                     placeholder="Actions (what did you do?)"
                                   />
                                   <input
                                     value={c.impact}
                                     onChange={(e) => setCaseStudies((prev) => prev.map((x, i) => (i === idx ? { ...x, impact: e.target.value } : x)))}
+                                    onFocus={() => setCaseStudyFocus({ caseIdx: idx, field: "impact" })}
                                     className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
                                     placeholder="Impact (what changed?)"
                                   />
@@ -1113,41 +1205,41 @@ export default function OfferPage() {
                           </div>
 
                           {/* Quick inserts for case studies */}
-                          {suggestedCaseStudies.length > 0 ? (
+                          {(caseStudyQuickInserts.problem.length > 0 ||
+                            caseStudyQuickInserts.actions.length > 0 ||
+                            caseStudyQuickInserts.impact.length > 0) ? (
                             <div className="mt-4 rounded-md border border-white/10 bg-white/5 p-3">
-                              <div className="text-[11px] font-semibold text-white/70 uppercase tracking-wider">Quick inserts (from your resume)</div>
-                              <div className="mt-2 flex flex-wrap gap-2">
-                                {suggestedCaseStudies.map((s, si) => {
-                                  const label = clampLines(s.actions || s.impact || s.problem, 60);
-                                  if (!label) return null;
-                                  return (
-                                    <button
-                                      key={`csq_${si}`}
-                                      type="button"
-                                      onClick={() =>
-                                        setCaseStudies((prev) => {
-                                          const next = [...(prev || [])];
-                                          const idx = next.findIndex(
-                                            (x) => !String(x.problem || "").trim() && !String(x.actions || "").trim() && !String(x.impact || "").trim()
-                                          );
-                                          const target = idx >= 0 ? idx : 0;
-                                          next[target] = {
-                                            ...next[target],
-                                            problem: s.problem || next[target].problem,
-                                            actions: s.actions || next[target].actions,
-                                            impact: s.impact || next[target].impact,
-                                          };
-                                          return next;
-                                        })
-                                      }
-                                      className="px-2 py-1 rounded-full border border-white/10 bg-black/20 text-[11px] text-white/80 hover:bg-black/30"
-                                      title="Insert into case study"
-                                    >
-                                      + {label}
-                                    </button>
-                                  );
-                                })}
+                              <div className="text-[11px] font-semibold text-white/70 uppercase tracking-wider">
+                                Quick inserts
+                                {caseStudyFocus ? (
+                                  <span className="normal-case font-normal text-white/50">
+                                    {" "}
+                                    → case study {caseStudyFocus.caseIdx + 1}, {caseStudyFocus.field}
+                                  </span>
+                                ) : (
+                                  <span className="normal-case font-normal text-white/50"> (click a field first)</span>
+                                )}
                               </div>
+                              {(["problem", "actions", "impact"] as const).map((field) =>
+                                caseStudyQuickInserts[field].length ? (
+                                  <div key={field} className="mt-2">
+                                    <div className="text-[10px] font-bold text-white/50 uppercase tracking-wider mb-1">{field}</div>
+                                    <div className="flex flex-wrap gap-2">
+                                      {caseStudyQuickInserts[field].map((item, qi) => (
+                                        <button
+                                          key={`${field}_${qi}`}
+                                          type="button"
+                                          onClick={() => insertCaseStudyField(field, item.text)}
+                                          className="px-2 py-1 rounded-full border border-white/10 bg-black/20 text-[11px] text-white/80 hover:bg-black/30"
+                                          title={`Insert into ${field}`}
+                                        >
+                                          + {item.label}
+                                        </button>
+                                      ))}
+                                    </div>
+                                  </div>
+                                ) : null
+                              )}
                             </div>
                           ) : null}
                           {defaultAllBtn("case_studies")}
@@ -1369,6 +1461,8 @@ export default function OfferPage() {
               })}
             </div>
           )}
+
+          <WorkflowSummary />
 
           {/* Footer */}
           <div className="mt-8 flex justify-end gap-3">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,47 +4,22 @@ import "./home_wireframe.css";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
+import RoutePicker from "@/components/RoutePicker";
+import {
+  ALL_STEPS,
+  RouteId,
+  WorkflowStep,
+  SNAKE_POSITIONS,
+  getActiveRoute,
+  getStepsForRoute,
+} from "@/lib/workflowRoutes";
 
-type StoneConfig = {
-  step: number;
-  tab: string;
-  label: string;
-  icon: string;
-  href: string;
-};
+type StoneConfig = WorkflowStep;
 
-const STONES: StoneConfig[] = [
-  { step: 1, tab: "job-preferences", label: "Role Preferences", icon: "🎯", href: "/job-preferences" },
-  { step: 2, tab: "candidate-profile", label: "Your Resume", icon: "📄", href: "/resume" },
-  { step: 3, tab: "personality", label: "Personality", icon: "🧠", href: "/personality" },
-  { step: 4, tab: "job-descriptions", label: "Role Search", icon: "🔎", href: "/job-descriptions" },
-  { step: 5, tab: "gap-analysis", label: "Gap Analysis", icon: "🧩", href: "/gap-analysis" },
-  { step: 6, tab: "pain-point-match", label: "Pain Point Match", icon: "🔗", href: "/painpoint-match" },
-  { step: 7, tab: "company-research", label: "Company Research", icon: "🏢", href: "/company-research" },
-  { step: 8, tab: "decision-makers", label: "Decision Makers", icon: "👤", href: "/find-contact" },
-  { step: 9, tab: "offer", label: "Offer", icon: "✨", href: "/offer" },
-  { step: 10, tab: "bio-page", label: "Bio Page", icon: "🌐", href: "/bio-page" },
-  { step: 11, tab: "apply", label: "Apply", icon: "✅", href: "/apply" },
-  { step: 12, tab: "campaign", label: "Campaign", icon: "📧", href: "/campaign" },
-];
+const STONES: StoneConfig[] = ALL_STEPS;
 
 const LEFT_FOOT_SRC = "/wireframes/assets/left-foot.gif";
 const RIGHT_FOOT_SRC = "/wireframes/assets/right-foot.gif";
-
-const POSITIONS: Record<number, { top: number; left: number }> = {
-  1: { top: 40, left: 20 },
-  2: { top: 40, left: 210 },
-  3: { top: 40, left: 400 },
-  4: { top: 40, left: 590 },
-  5: { top: 160, left: 590 },
-  6: { top: 160, left: 400 },
-  7: { top: 160, left: 210 },
-  8: { top: 160, left: 20 },
-  9: { top: 320, left: 20 },
-  10: { top: 320, left: 210 },
-  11: { top: 320, left: 400 },
-  12: { top: 320, left: 590 },
-};
 
 export default function Home() {
   const router = useRouter();
@@ -52,6 +27,19 @@ export default function Home() {
   const [isAnimating, setIsAnimating] = useState(false);
   const [visibleFootstepsUpTo, setVisibleFootstepsUpTo] = useState<number>(0);
   const [bannerClosed, setBannerClosed] = useState(false);
+  const [activeRoute, setActiveRouteState] = useState<RouteId | null>(null);
+
+  useEffect(() => {
+    setActiveRouteState(getActiveRoute());
+    const onRoute = () => setActiveRouteState(getActiveRoute());
+    window.addEventListener("rf-route-changed", onRoute);
+    return () => window.removeEventListener("rf-route-changed", onRoute);
+  }, []);
+
+  const visibleStones = useMemo(
+    () => (activeRoute ? getStepsForRoute(activeRoute) : []),
+    [activeRoute]
+  );
 
   useEffect(() => {
     function loadCompletedFromStorage() {
@@ -238,7 +226,7 @@ export default function Home() {
     }
   }
 
-  function handleStepClick(stone: StoneConfig) {
+  function handleStepClick(stone: StoneConfig, displayIdx: number) {
     if (isAnimating) return;
 
     const next = new Set(completed);
@@ -246,7 +234,7 @@ export default function Home() {
     setCompleted(next);
     saveProgress(next);
 
-    playFootstepSequence(stone.step, () => router.push(stone.href));
+    playFootstepSequence(displayIdx + 1, () => router.push(stone.href));
   }
 
   return (
@@ -305,17 +293,26 @@ export default function Home() {
             <img src="/ani-sm.gif" alt="RoleFerry Animation" className="animated-logo" />
           </div>
           <h1 className="keypad-title">The Path to Your Next Role</h1>
-          <p className="keypad-subtitle">Transform your role search with intelligent automation</p>
+          <p className="keypad-subtitle">Choose your route, then set sail on your journey</p>
         </div>
 
+        <div className="px-4 pb-6 max-w-4xl mx-auto">
+          <RoutePicker onRouteSelected={(r) => setActiveRouteState(r)} />
+        </div>
+
+        {!activeRoute && (
+          <p className="text-center text-sm text-white/50 pb-8 px-4">
+            Select a route above to reveal your workflow steps.
+          </p>
+        )}
+
+        {activeRoute && (
         <div className="path-container" id="pathContainer">
-          {STONES.map((stone) => {
-            const pos = POSITIONS[stone.step];
-            const showFootstep = visibleFootstepsUpTo >= stone.step;
-            const footSrc = footstepsForStep.get(stone.step) || LEFT_FOOT_SRC;
-            // Row 2 (steps 5–8) animates right-to-left, so flip footprints to match direction.
-            // Row 1 and Row 3 animate left-to-right (default orientation).
-            const flipFootstep = stone.step >= 5 && stone.step <= 8;
+          {visibleStones.map((stone, displayIdx) => {
+            const pos = SNAKE_POSITIONS[displayIdx] || SNAKE_POSITIONS[displayIdx % SNAKE_POSITIONS.length];
+            const showFootstep = visibleFootstepsUpTo >= displayIdx + 1;
+            const footSrc = footstepsForStep.get(displayIdx + 1) || LEFT_FOOT_SRC;
+            const flipFootstep = displayIdx >= 4 && displayIdx <= 7;
             return (
               <div
                 key={stone.step}
@@ -323,15 +320,15 @@ export default function Home() {
                 data-tab={stone.tab}
                 data-step={stone.step}
                 title={stone.label}
-                onClick={() => handleStepClick(stone)}
+                onClick={() => handleStepClick(stone, displayIdx)}
                 style={{ top: pos.top, left: pos.left }}
                 role="button"
                 tabIndex={0}
-                onKeyDown={(e) => e.key === "Enter" && handleStepClick(stone)}
+                onKeyDown={(e) => e.key === "Enter" && handleStepClick(stone, displayIdx)}
               >
                 <img src="/assets/stones.png" alt="Stone" className="stone-image" />
                 <div className="stone-content">
-                  <div className="stone-step-number">{stone.step}</div>
+                  <div className="stone-step-number">{displayIdx + 1}</div>
                   <div className="icon">{stone.icon}</div>
                   <div className="stone-label-text">{stone.label}</div>
                 </div>
@@ -347,6 +344,7 @@ export default function Home() {
             );
           })}
         </div>
+        )}
 
       </div>
     </div>

--- a/frontend/src/app/personality/page.tsx
+++ b/frontend/src/app/personality/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import CollapsibleSection from "@/components/CollapsibleSection";
+import WorkflowSummary from "@/components/WorkflowSummary";
+import { getActiveRoute, ROUTE_DEFINITIONS } from "@/lib/workflowRoutes";
 
 type Choice = -2 | -1 | 0 | 1 | 2;
 
@@ -798,6 +800,19 @@ export default function PersonalityPage() {
             </div>
           </div>
 
+          {(() => {
+            const route = getActiveRoute();
+            const routeDef = ROUTE_DEFINITIONS.find((r) => r.id === route);
+            if (!routeDef) return null;
+            return (
+              <div className="mb-6 flex flex-wrap items-center gap-2 rounded-lg border border-white/10 bg-black/20 px-4 py-2">
+                <span className="text-[10px] font-bold uppercase tracking-wider text-white/45">Optional on this route</span>
+                <span className="text-xs font-semibold text-white/85">{routeDef.badge} — {routeDef.title}</span>
+                <span className="text-xs text-white/50">· {routeDef.strategy}</span>
+              </div>
+            );
+          })()}
+
           <div className="mb-6 rounded-lg border border-white/10 bg-black/20 p-4">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
               <div>
@@ -1350,6 +1365,8 @@ export default function PersonalityPage() {
             </div>
           )}
         </div>
+
+        <WorkflowSummary />
       </div>
     </div>
   );

--- a/frontend/src/app/resume/page.tsx
+++ b/frontend/src/app/resume/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { formatCompanyName } from "@/lib/format";
 import InlineSpinner from "@/components/InlineSpinner";
 import CollapsibleSection from "@/components/CollapsibleSection";
+import WorkflowSummary from "@/components/WorkflowSummary";
 
 
 interface ResumeExtract {
@@ -171,6 +172,20 @@ export default function ResumePage() {
   const [isEditing, setIsEditing] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [cachedFilename, setCachedFilename] = useState<string | null>(null);
+  const [careerResult, setCareerResult] = useState("");
+
+  function suggestCareerResult(ex: ResumeExtract | null): string {
+    if (!ex) return "";
+    const km = ex.keyMetrics?.[0];
+    if (km?.metric && km?.value) {
+      return `${km.metric}: ${km.value}${km.context ? ` (${km.context})` : ""}`.trim();
+    }
+    const acc = ex.accomplishments?.[0];
+    if (acc) return String(acc).trim();
+    const pos = ex.positions?.[0];
+    if (pos?.description) return String(pos.description).split(/[•\n]/)[0]?.trim().slice(0, 180) || "";
+    return "";
+  }
 
   const totalYearsExperience = (() => {
     if (!extract?.positions?.length) return null;
@@ -239,6 +254,10 @@ export default function ResumePage() {
         const meta = JSON.parse(metaRaw);
         if (meta?.filename) setCachedFilename(String(meta.filename));
       }
+      const savedCareer = localStorage.getItem("rf_career_result");
+      if (savedCareer) {
+        setCareerResult(savedCareer);
+      }
     } catch {
       // If cache is corrupt, clear it silently.
       try {
@@ -247,6 +266,12 @@ export default function ResumePage() {
       } catch {}
     }
   }, []);
+
+  useEffect(() => {
+    if (!extract || careerResult.trim()) return;
+    const suggested = suggestCareerResult(extract);
+    if (suggested) setCareerResult(suggested);
+  }, [extract]);
 
   const handleFileUpload = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -374,6 +399,9 @@ export default function ResumePage() {
       };
       localStorage.setItem("resume_extract", JSON.stringify(withNumbered));
       localStorage.setItem("resume_extract_numbered", JSON.stringify(withNumbered.numbered || {}));
+      if (careerResult.trim()) {
+        localStorage.setItem("rf_career_result", careerResult.trim());
+      }
       router.push("/personality");
     }
   };
@@ -848,6 +876,30 @@ export default function ResumePage() {
                   </div>
                 ) : null}
               </CollapsibleSection>
+
+              <CollapsibleSection title="Strongest career result" count={careerResult.trim() ? 1 : 0}>
+                <p className="text-sm text-white/70 mb-3">
+                  Your single best proof point — used in targeting, outreach, and your bio. Auto-filled from your resume; edit if needed.
+                </p>
+                <textarea
+                  value={careerResult}
+                  onChange={(e) => setCareerResult(e.target.value)}
+                  rows={3}
+                  className="w-full rounded-md border border-white/15 bg-black/30 px-3 py-2 text-sm text-white placeholder:text-white/40 outline-none focus:ring-2 focus:ring-blue-500"
+                  placeholder='e.g., "Reduced churn 18% by rebuilding onboarding in 90 days"'
+                />
+                {extract && (
+                  <button
+                    type="button"
+                    onClick={() => setCareerResult(suggestCareerResult(extract))}
+                    className="mt-2 text-xs text-blue-300 hover:text-blue-200 underline"
+                  >
+                    Re-extract from resume
+                  </button>
+                )}
+              </CollapsibleSection>
+
+              <WorkflowSummary />
 
               <div className="flex justify-end space-x-4">
                 <button

--- a/frontend/src/components/Dream100TargetingPanel.tsx
+++ b/frontend/src/components/Dream100TargetingPanel.tsx
@@ -1,0 +1,380 @@
+"use client";
+
+import { useState } from "react";
+import { api } from "@/lib/api";
+import InlineSpinner from "@/components/InlineSpinner";
+import { getActiveRoute } from "@/lib/workflowRoutes";
+
+export type IdealCompanyCriteria = {
+  headcount: string;
+  growth_signals: string[];
+  funding_stage: string;
+  tech_stack_clues: string[];
+  content_activity: string;
+  summary: string;
+};
+
+export type ActiveNeedSignal = { signal: string; why_it_matters: string };
+export type RedFlag = { flag: string; disqualify_reason: string };
+export type ChannelPlaybookItem = {
+  channel: string;
+  how_to: string[];
+  example_search?: string;
+  url?: string;
+};
+export type ScoringFactor = { factor: string; weight: string; score_guide: string };
+export type SampleTarget = {
+  company_type: string;
+  team_structure: string;
+  why_fit: string;
+  where_to_find_contact: string;
+  hook_angle: string;
+  example_score: number;
+};
+
+export type Dream100Targeting = {
+  generated_at?: string;
+  ideal_company: IdealCompanyCriteria;
+  active_need_signals: ActiveNeedSignal[];
+  red_flags: RedFlag[];
+  channel_playbook: ChannelPlaybookItem[];
+  scoring_rubric: {
+    overview: string;
+    factors: ScoringFactor[];
+    how_to_use: string;
+  };
+  sample_targets: SampleTarget[];
+};
+
+type Props = {
+  preferences: {
+    values: string[];
+    roleCategories: string[];
+    locationPreferences: string[];
+    workType: string[];
+    roleType: string[];
+    companySize: string[];
+    industries: string[];
+    skills: string[];
+    minimumSalary: string;
+    jobSearchStatus: string;
+    state?: string;
+    metroAreas?: string[];
+    locationText?: string;
+  };
+  dream100?: {
+    positioningLevel: string;
+  };
+  targeting: Dream100Targeting | null;
+  onTargetingChange: (t: Dream100Targeting) => void;
+};
+
+function scoreColor(score: number) {
+  if (score >= 8) return "text-emerald-300 border-emerald-500/30 bg-emerald-500/10";
+  if (score >= 5) return "text-yellow-300 border-yellow-500/30 bg-yellow-500/10";
+  return "text-red-300 border-red-500/30 bg-red-500/10";
+}
+
+export default function Dream100TargetingPanel({
+  preferences,
+  dream100,
+  targeting,
+  onTargetingChange,
+}: Props) {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedTarget, setExpandedTarget] = useState<number | null>(0);
+
+  const canGenerate =
+    preferences.roleCategories.length > 0 ||
+    preferences.industries.length > 0 ||
+    preferences.skills.length > 0;
+
+  const handleGenerate = async () => {
+    setIsGenerating(true);
+    setError(null);
+    try {
+      let resumeExtract: unknown = null;
+      try {
+        resumeExtract = JSON.parse(localStorage.getItem("resume_extract") || "null");
+      } catch {}
+
+      const res = await api<{
+        success: boolean;
+        targeting: Dream100Targeting;
+        used_llm?: boolean;
+      }>("/job-preferences/dream100-targeting", "POST", {
+        preferences: {
+          values: preferences.values,
+          role_categories: preferences.roleCategories,
+          location_preferences: preferences.locationPreferences,
+          location_text: preferences.locationText || "",
+          work_type: preferences.workType,
+          role_type: preferences.roleType,
+          company_size: preferences.companySize,
+          industries: preferences.industries,
+          skills: preferences.skills,
+          minimum_salary: preferences.minimumSalary,
+          job_search_status: preferences.jobSearchStatus,
+          state: preferences.state || "",
+          metro_areas: preferences.metroAreas || [],
+        },
+        dream100: {
+          positioning_level: dream100?.positioningLevel || getActiveRoute() || "",
+          career_result: localStorage.getItem("rf_career_result") || "",
+          free_deliverable: localStorage.getItem("rf_free_deliverable") || "",
+        },
+        resume_extract: resumeExtract,
+      });
+
+      if (res?.targeting) {
+        const next = { ...res.targeting, generated_at: new Date().toISOString() };
+        onTargetingChange(next);
+        try {
+          localStorage.setItem("rf_dream100_targeting", JSON.stringify(next));
+        } catch {}
+      }
+    } catch (e: unknown) {
+      setError(String((e as Error)?.message || "Failed to generate targeting plan."));
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <p className="text-sm text-white/70 flex-1">
+          Define who to pursue, where to find them, how to score companies, and get 10 example target types tailored to your background.
+        </p>
+        <button
+          type="button"
+          onClick={handleGenerate}
+          disabled={isGenerating || !canGenerate}
+          className="shrink-0 px-4 py-2 rounded-md bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-2"
+          title={!canGenerate ? "Fill in at least role category, industry, or skills below first" : undefined}
+        >
+          {isGenerating ? (
+            <>
+              <InlineSpinner className="h-4 w-4" />
+              Generating...
+            </>
+          ) : targeting ? (
+            "Regenerate plan"
+          ) : (
+            "Generate targeting plan"
+          )}
+        </button>
+      </div>
+
+      {!canGenerate && (
+        <p className="text-xs text-amber-300/80 border border-amber-500/20 bg-amber-500/10 rounded px-3 py-2">
+          Select at least one role category, industry, or skill in the preference sections above before generating.
+        </p>
+      )}
+
+      {error && (
+        <p className="text-xs text-red-300 border border-red-500/20 bg-red-500/10 rounded px-3 py-2">{error}</p>
+      )}
+
+      {!targeting && !isGenerating && (
+        <p className="text-sm text-white/40 italic">
+          No targeting plan yet. Generate one to see ideal company criteria, channel playbook, scoring rubric, and sample targets.
+        </p>
+      )}
+
+      {targeting && (
+        <div className="space-y-5">
+          {/* 1. Ideal company criteria */}
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4 space-y-3">
+            <div className="text-xs font-bold text-blue-300 uppercase tracking-wider">1. Ideal Target Company Profile</div>
+            {targeting.ideal_company.summary && (
+              <p className="text-sm text-white/80">{targeting.ideal_company.summary}</p>
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3 text-xs">
+              {targeting.ideal_company.headcount && (
+                <div>
+                  <span className="text-white/50 uppercase tracking-wider font-semibold">Headcount</span>
+                  <p className="text-white/80 mt-0.5">{targeting.ideal_company.headcount}</p>
+                </div>
+              )}
+              {targeting.ideal_company.funding_stage && (
+                <div>
+                  <span className="text-white/50 uppercase tracking-wider font-semibold">Funding stage</span>
+                  <p className="text-white/80 mt-0.5">{targeting.ideal_company.funding_stage}</p>
+                </div>
+              )}
+              {targeting.ideal_company.content_activity && (
+                <div className="md:col-span-2">
+                  <span className="text-white/50 uppercase tracking-wider font-semibold">Content activity</span>
+                  <p className="text-white/80 mt-0.5">{targeting.ideal_company.content_activity}</p>
+                </div>
+              )}
+            </div>
+            {targeting.ideal_company.growth_signals?.length > 0 && (
+              <div>
+                <div className="text-[10px] text-white/50 uppercase tracking-wider font-semibold mb-1">Growth signals</div>
+                <ul className="space-y-1">
+                  {targeting.ideal_company.growth_signals.map((s, i) => (
+                    <li key={i} className="text-xs text-white/75 flex gap-2">
+                      <span className="text-emerald-400 shrink-0">+</span>{s}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {targeting.ideal_company.tech_stack_clues?.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {targeting.ideal_company.tech_stack_clues.map((t, i) => (
+                  <span key={i} className="text-[10px] px-2 py-0.5 rounded-full border border-white/10 bg-white/5 text-white/70">{t}</span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Active need signals + red flags */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-4 space-y-2">
+              <div className="text-xs font-bold text-emerald-300 uppercase tracking-wider">Actively in need (pursue)</div>
+              {(targeting.active_need_signals || []).map((s, i) => (
+                <div key={i} className="text-xs">
+                  <div className="text-white/90 font-medium">{s.signal}</div>
+                  {s.why_it_matters && <div className="text-white/50 mt-0.5">{s.why_it_matters}</div>}
+                </div>
+              ))}
+            </div>
+            <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-4 space-y-2">
+              <div className="text-xs font-bold text-red-300 uppercase tracking-wider">Red flags (skip immediately)</div>
+              {(targeting.red_flags || []).map((r, i) => (
+                <div key={i} className="text-xs">
+                  <div className="text-white/90 font-medium">{r.flag}</div>
+                  {r.disqualify_reason && <div className="text-white/50 mt-0.5">{r.disqualify_reason}</div>}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 2. Channel playbook */}
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4 space-y-3">
+            <div className="text-xs font-bold text-blue-300 uppercase tracking-wider">2. Where to Find Them</div>
+            <div className="space-y-3">
+              {(targeting.channel_playbook || []).map((ch, i) => (
+                <div key={i} className="border border-white/10 rounded-md p-3 bg-white/5">
+                  <div className="flex items-center justify-between gap-2 mb-1.5">
+                    <div className="text-sm font-semibold text-white">{ch.channel}</div>
+                    {ch.url && (
+                      <a
+                        href={ch.url.startsWith("/") ? ch.url : ch.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-[10px] text-blue-300 hover:text-blue-200 underline shrink-0"
+                      >
+                        Open search
+                      </a>
+                    )}
+                  </div>
+                  <ul className="space-y-1 mb-2">
+                    {(ch.how_to || []).map((step, j) => (
+                      <li key={j} className="text-xs text-white/70 flex gap-2">
+                        <span className="text-white/30 shrink-0">{j + 1}.</span>{step}
+                      </li>
+                    ))}
+                  </ul>
+                  {ch.example_search && (
+                    <div className="text-[10px] font-mono text-white/50 bg-black/30 rounded px-2 py-1 break-all">
+                      {ch.example_search}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* 3. Scoring rubric */}
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4 space-y-3">
+            <div className="text-xs font-bold text-blue-300 uppercase tracking-wider">3. Company Scoring Rubric (1-10)</div>
+            {targeting.scoring_rubric?.overview && (
+              <p className="text-sm text-white/75">{targeting.scoring_rubric.overview}</p>
+            )}
+            <div className="space-y-2">
+              {(targeting.scoring_rubric?.factors || []).map((f, i) => (
+                <div key={i} className="border border-white/10 rounded-md p-2.5 bg-white/5">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-xs font-semibold text-white">{f.factor}</span>
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded border ${
+                      f.weight === "high" ? "border-orange-500/30 text-orange-300 bg-orange-500/10" :
+                      f.weight === "low" ? "border-white/20 text-white/40" :
+                      "border-white/20 text-white/60"
+                    }`}>{f.weight}</span>
+                  </div>
+                  <p className="text-[11px] text-white/60">{f.score_guide}</p>
+                </div>
+              ))}
+            </div>
+            {targeting.scoring_rubric?.how_to_use && (
+              <p className="text-xs text-white/50 italic border-t border-white/10 pt-2">{targeting.scoring_rubric.how_to_use}</p>
+            )}
+          </div>
+
+          {/* 4. Sample targets */}
+          <div className="rounded-lg border border-white/10 bg-black/20 p-4 space-y-3">
+            <div className="text-xs font-bold text-blue-300 uppercase tracking-wider">4. Sample Target List (10 archetypes)</div>
+            <div className="space-y-2">
+              {(targeting.sample_targets || []).map((t, i) => {
+                const open = expandedTarget === i;
+                return (
+                  <div key={i} className="border border-white/10 rounded-md overflow-hidden">
+                    <button
+                      type="button"
+                      onClick={() => setExpandedTarget(open ? null : i)}
+                      className="w-full flex items-center justify-between gap-3 px-3 py-2.5 bg-white/5 hover:bg-white/10 text-left transition-colors"
+                    >
+                      <span className="text-sm text-white font-medium">{t.company_type}</span>
+                      <span className={`text-[10px] font-bold px-2 py-0.5 rounded border shrink-0 ${scoreColor(t.example_score)}`}>
+                        {t.example_score}/10
+                      </span>
+                    </button>
+                    {open && (
+                      <div className="px-3 py-2.5 space-y-2 border-t border-white/10 text-xs">
+                        {t.team_structure && (
+                          <div>
+                            <span className="text-white/50 uppercase tracking-wider font-semibold text-[10px]">Team structure</span>
+                            <p className="text-white/75 mt-0.5">{t.team_structure}</p>
+                          </div>
+                        )}
+                        {t.why_fit && (
+                          <div>
+                            <span className="text-white/50 uppercase tracking-wider font-semibold text-[10px]">Why you fit</span>
+                            <p className="text-white/75 mt-0.5">{t.why_fit}</p>
+                          </div>
+                        )}
+                        {t.where_to_find_contact && (
+                          <div>
+                            <span className="text-white/50 uppercase tracking-wider font-semibold text-[10px]">Find contact via</span>
+                            <p className="text-white/75 mt-0.5">{t.where_to_find_contact}</p>
+                          </div>
+                        )}
+                        {t.hook_angle && (
+                          <div className="rounded border border-blue-500/20 bg-blue-600/10 px-2.5 py-2">
+                            <span className="text-blue-300 uppercase tracking-wider font-semibold text-[10px]">Hook angle</span>
+                            <p className="text-white/90 mt-0.5 font-medium">{t.hook_angle}</p>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {targeting.generated_at && (
+            <p className="text-[10px] text-white/30 text-right">
+              Generated {new Date(targeting.generated_at).toLocaleString()}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -4,12 +4,22 @@ import { useEffect, useState } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { api } from "@/lib/api";
 import DataModal from "./DataModal";
+import { getActiveRoute, getStepsForRoute } from "@/lib/workflowRoutes";
 
-const STEP_PATHS: Record<number, string> = {
-  1: "/job-preferences", 2: "/resume", 3: "/personality", 4: "/job-descriptions",
-  5: "/gap-analysis", 6: "/painpoint-match", 7: "/company-research", 8: "/find-contact",
-  9: "/offer", 10: "/bio-page", 11: "/apply", 12: "/campaign",
-};
+const NAV_STEPS: Array<{ step: number; href: string; label: string }> = [
+  { step: 1, href: "/job-preferences", label: "Prefs" },
+  { step: 2, href: "/resume", label: "Resume" },
+  { step: 3, href: "/personality", label: "Persona" },
+  { step: 4, href: "/job-descriptions", label: "Roles" },
+  { step: 5, href: "/gap-analysis", label: "Gaps" },
+  { step: 6, href: "/painpoint-match", label: "Match" },
+  { step: 7, href: "/company-research", label: "Research" },
+  { step: 8, href: "/find-contact", label: "Contact" },
+  { step: 9, href: "/offer", label: "Offer" },
+  { step: 10, href: "/bio-page", label: "Bio" },
+  { step: 11, href: "/apply", label: "Apply" },
+  { step: 12, href: "/campaign", label: "Campaign" },
+];
 
 export default function Navbar() {
   const router = useRouter();
@@ -17,6 +27,7 @@ export default function Navbar() {
   const [dataOpen, setDataOpen] = useState(false);
   const [user, setUser] = useState<any>(null);
   const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  const [visibleNavSteps, setVisibleNavSteps] = useState<number[]>(NAV_STEPS.map((s) => s.step));
   
   // Re-read user from localStorage on every client-side navigation so the
   // greeting updates after login/register (which write rf_user then navigate).
@@ -36,7 +47,19 @@ export default function Navbar() {
         setCompletedSteps(new Set(steps.filter((n) => Number.isFinite(n))));
       }
     } catch {}
+
+    const route = getActiveRoute();
+    setVisibleNavSteps(getStepsForRoute(route).map((s) => s.step));
   }, [pathname]);
+
+  useEffect(() => {
+    const onRoute = () => {
+      const route = getActiveRoute();
+      setVisibleNavSteps(getStepsForRoute(route).map((s) => s.step));
+    };
+    window.addEventListener("rf-route-changed", onRoute);
+    return () => window.removeEventListener("rf-route-changed", onRoute);
+  }, []);
 
   useEffect(() => {
     // RoleFerry is currently Role-Seeker only.
@@ -180,18 +203,11 @@ export default function Navbar() {
             <NavPill href="/" pathname={pathname} kind="utility" size="md">Dashboard</NavPill>
             <span className="mx-2 h-4 w-px bg-white/15" />
 
-            <NavPill href="/job-preferences" pathname={pathname} done={completedSteps.has(1)}>Prefs</NavPill>
-            <NavPill href="/resume" pathname={pathname} done={completedSteps.has(2)}>Resume</NavPill>
-            <NavPill href="/personality" pathname={pathname} done={completedSteps.has(3)}>Persona</NavPill>
-            <NavPill href="/job-descriptions" pathname={pathname} done={completedSteps.has(4)}>Roles</NavPill>
-            <NavPill href="/gap-analysis" pathname={pathname} done={completedSteps.has(5)}>Gaps</NavPill>
-            <NavPill href="/painpoint-match" pathname={pathname} done={completedSteps.has(6)}>Match</NavPill>
-            <NavPill href="/company-research" pathname={pathname} done={completedSteps.has(7)}>Research</NavPill>
-            <NavPill href="/find-contact" pathname={pathname} done={completedSteps.has(8)}>Contact</NavPill>
-            <NavPill href="/offer" pathname={pathname} done={completedSteps.has(9)}>Offer</NavPill>
-            <NavPill href="/bio-page" pathname={pathname} done={completedSteps.has(10)}>Bio</NavPill>
-            <NavPill href="/apply" pathname={pathname} done={completedSteps.has(11)}>Apply</NavPill>
-            <NavPill href="/campaign" pathname={pathname} done={completedSteps.has(12)}>Campaign</NavPill>
+            {NAV_STEPS.filter((s) => visibleNavSteps.includes(s.step)).map((s) => (
+              <NavPill key={s.step} href={s.href} pathname={pathname} done={completedSteps.has(s.step)}>
+                {s.label}
+              </NavPill>
+            ))}
             <NavPill href="/deliverability-launch" pathname={pathname}>Launch</NavPill>
 
             {/* Big spacing: steps vs non-step utilities */}

--- a/frontend/src/components/RoutePicker.tsx
+++ b/frontend/src/components/RoutePicker.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import {
+  ROUTE_DEFINITIONS,
+  RouteId,
+  getActiveRoute,
+  setActiveRoute,
+} from "@/lib/workflowRoutes";
+
+type Props = {
+  onRouteSelected?: (route: RouteId) => void;
+  compact?: boolean;
+};
+
+export default function RoutePicker({ onRouteSelected, compact = false }: Props) {
+  const [selected, setSelected] = useState<RouteId | null>(() => getActiveRoute());
+
+  const pick = (id: RouteId) => {
+    setSelected(id);
+    setActiveRoute(id);
+    onRouteSelected?.(id);
+  };
+
+  return (
+    <div className={compact ? "space-y-3" : "space-y-4"}>
+      {!compact && (
+        <div className="text-center space-y-1">
+          <h2 className="text-xl font-bold text-white">Choose your route</h2>
+          <p className="text-sm text-white/60 max-w-xl mx-auto">
+            Pick one route for this journey. Route 1 uses posted roles. Routes 2 and 3 skip job search and focus on company research and outreach.
+          </p>
+        </div>
+      )}
+
+      <div className={`grid grid-cols-1 ${compact ? "md:grid-cols-3" : "md:grid-cols-3"} gap-3`}>
+        {ROUTE_DEFINITIONS.map((r) => {
+          const active = selected === r.id;
+          return (
+            <button
+              key={r.id}
+              type="button"
+              onClick={() => pick(r.id)}
+              className={`relative text-left rounded-xl border p-4 transition-all ${
+                active
+                  ? `${r.accent} ring-2`
+                  : "border-white/10 bg-white/5 hover:border-white/25 hover:bg-white/10"
+              }`}
+            >
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border ${
+                  active ? "border-white/30 text-white bg-white/10" : "border-white/15 text-white/50"
+                }`}>
+                  {r.badge}
+                </span>
+                <span className="text-xl" aria-hidden>{r.icon}</span>
+              </div>
+              <div className={`text-base font-bold mb-1 ${active ? "text-white" : "text-white/90"}`}>
+                {r.title}
+              </div>
+              <div className="text-xs text-white/65 mb-2 leading-relaxed">{r.subtitle}</div>
+              <div className={`text-xs font-medium ${active ? "text-blue-200" : "text-white/45"}`}>
+                {r.strategy}
+              </div>
+              <div className="mt-2 text-[10px] text-white/40 uppercase tracking-wide">{r.difficulty} difficulty</div>
+            </button>
+          );
+        })}
+      </div>
+
+      {selected && selected !== "1" && (
+        <p className="text-xs text-amber-200/90 border border-amber-500/25 bg-amber-500/10 rounded-lg px-3 py-2 text-center">
+          Route {selected} skips Role Search and Gap Analysis. You go Personality → Research → Pain Point Match → outreach.
+        </p>
+      )}
+
+      {selected === "1" && (
+        <p className="text-xs text-emerald-200/80 border border-emerald-500/20 bg-emerald-500/10 rounded-lg px-3 py-2 text-center">
+          Route 1 includes the full job search: roles, gaps, match, then research and outreach.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WorkflowSummary.tsx
+++ b/frontend/src/components/WorkflowSummary.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { getActiveRoute, ROUTE_DEFINITIONS } from "@/lib/workflowRoutes";
+
+function safeJson<T>(raw: string | null, fallback: T): T {
+  try {
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export default function WorkflowSummary() {
+  const [open, setOpen] = useState(false);
+
+  const summary = useMemo(() => {
+    if (typeof window === "undefined") return null;
+    const route = getActiveRoute();
+    const routeDef = ROUTE_DEFINITIONS.find((r) => r.id === route);
+    const prefs = safeJson<any>(localStorage.getItem("job_preferences"), null);
+    const resume = safeJson<any>(localStorage.getItem("resume_extract"), null);
+    const careerResult = localStorage.getItem("rf_career_result") || "";
+    const deliverable = localStorage.getItem("rf_free_deliverable") || "";
+    const targeting = safeJson<any>(localStorage.getItem("rf_dream100_targeting"), null);
+    const company = localStorage.getItem("selected_company_name") || "";
+
+    const roles = (prefs?.roleCategories || []).slice(0, 3).join(", ");
+    const industries = (prefs?.industries || []).slice(0, 3).join(", ");
+    const sizes = (prefs?.companySize || []).slice(0, 2).join(", ");
+    const title = resume?.positions?.[0]?.title || resume?.Name || "";
+    const topMetric = resume?.key_metrics?.[0]?.metric
+      ? `${resume.key_metrics[0].metric}: ${resume.key_metrics[0].value || ""}`.trim()
+      : "";
+
+    return {
+      route: routeDef ? `${routeDef.badge} — ${routeDef.title}` : "Not selected",
+      roleFunction: roles || title || "Not set",
+      idealCompany: targeting?.ideal_company?.summary || sizes || industries || "Not set",
+      careerResult: careerResult || topMetric || "Add on Resume page",
+      deliverable: deliverable || "Add on Offer page",
+      industries: industries || "Not set",
+      company: company || "",
+    };
+  }, [open]);
+
+  if (!summary) return null;
+
+  const rows: Array<{ label: string; value: string }> = [
+    { label: "Active route", value: summary.route },
+    { label: "Role / function", value: summary.roleFunction },
+    { label: "Ideal company type", value: summary.idealCompany },
+    { label: "Strongest career result", value: summary.careerResult },
+    { label: "Free deliverable", value: summary.deliverable },
+    { label: "Target industries", value: summary.industries },
+  ];
+  if (summary.company) rows.push({ label: "Current company focus", value: summary.company });
+
+  return (
+    <div className="mt-8 rounded-lg border border-white/10 bg-black/20 overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between px-4 py-3 text-left hover:bg-white/5 transition-colors"
+      >
+        <div>
+          <div className="text-xs font-bold text-blue-300 uppercase tracking-wider">Overview</div>
+          <div className="text-sm text-white/70">This is what we gathered so far</div>
+        </div>
+        <span className="text-white/40 text-sm">{open ? "▲" : "▼"}</span>
+      </button>
+      {open && (
+        <div className="px-4 pb-4 space-y-2 border-t border-white/10 pt-3">
+          {rows.map((r) => (
+            <div key={r.label} className="grid grid-cols-1 sm:grid-cols-[140px_1fr] gap-1 text-xs">
+              <span className="text-white/45 font-medium">{r.label}</span>
+              <span className="text-white/85">{r.value}</span>
+            </div>
+          ))}
+          <p className="text-[10px] text-white/35 pt-2">
+            Review and fix anything that looks wrong before generating outreach.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/campaignContext.ts
+++ b/frontend/src/lib/campaignContext.ts
@@ -1,7 +1,17 @@
+import { getActiveRoute } from "./workflowRoutes";
+
 export type Dream100Context = {
   positioning_level: "1" | "2" | "3" | "";
   career_result: string;
   free_deliverable: string;
+};
+
+export type Dream100TargetingContext = {
+  ideal_company?: Record<string, unknown>;
+  active_need_signals?: Array<{ signal: string; why_it_matters?: string }>;
+  red_flags?: Array<{ flag: string; disqualify_reason?: string }>;
+  scoring_rubric?: Record<string, unknown>;
+  sample_targets?: Array<Record<string, unknown>>;
 };
 
 export type RFCampaignContextV1 = {
@@ -30,6 +40,7 @@ export type RFCampaignContextV1 = {
   selected_contact_signals?: any[];
   selected_company_signals?: any[];
   dream100?: Dream100Context;
+  dream100_targeting?: Dream100TargetingContext;
   links?: {
     bio_page_url?: string;
     work_link?: string;
@@ -154,14 +165,33 @@ export function buildCampaignContextV1(contactId: string): RFCampaignContextV1 {
   const contactResearch = cid && contactResearchByContact ? contactResearchByContact[cid] : null;
 
   const d100Raw = safeJson<any>(lsGet("rf_dream100"), null);
+  const activeRoute = getActiveRoute();
+  const careerResult =
+    String(lsGet("rf_career_result") || "").trim() ||
+    String(d100Raw?.careerResult || "").trim();
+  const freeDeliverable =
+    String(lsGet("rf_free_deliverable") || "").trim() ||
+    String(d100Raw?.freeDeliverable || "").trim();
+  const positioningLevel = activeRoute || d100Raw?.positioningLevel || d100Raw?.selectedRoute || "";
   const dream100: Dream100Context | undefined =
-    d100Raw && (d100Raw.positioningLevel || d100Raw.careerResult || d100Raw.freeDeliverable)
+    positioningLevel || careerResult || freeDeliverable
       ? {
-          positioning_level: d100Raw.positioningLevel || "",
-          career_result: d100Raw.careerResult || "",
-          free_deliverable: d100Raw.freeDeliverable || "",
+          positioning_level: positioningLevel as Dream100Context["positioning_level"],
+          career_result: careerResult,
+          free_deliverable: freeDeliverable,
         }
       : undefined;
+
+  const d100TargetingRaw = safeJson<any>(lsGet("rf_dream100_targeting"), null);
+  const dream100_targeting: Dream100TargetingContext | undefined = d100TargetingRaw
+    ? {
+        ideal_company: d100TargetingRaw.ideal_company,
+        active_need_signals: d100TargetingRaw.active_need_signals,
+        red_flags: d100TargetingRaw.red_flags,
+        scoring_rubric: d100TargetingRaw.scoring_rubric,
+        sample_targets: d100TargetingRaw.sample_targets,
+      }
+    : undefined;
 
   const bioPageUrl = String(lsGet("bio_page_url") || "").trim();
 
@@ -193,6 +223,7 @@ export function buildCampaignContextV1(contactId: string): RFCampaignContextV1 {
     selected_contact_signals: safeJson<any[]>(lsGet("rf_selected_contact_signals"), []),
     selected_company_signals: safeJson<any[]>(lsGet("rf_selected_company_signals"), []),
     dream100,
+    dream100_targeting,
     links,
   };
 }

--- a/frontend/src/lib/useRouteGuard.ts
+++ b/frontend/src/lib/useRouteGuard.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { getActiveRoute, isStepSkippedForRoute } from "@/lib/workflowRoutes";
+
+/** Redirect away from steps not on the active route (e.g. Roles/Gaps on Route 2/3). */
+export function useRouteGuard(step: number) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const route = getActiveRoute();
+    if (isStepSkippedForRoute(step, route)) {
+      router.replace("/");
+    }
+  }, [step, router]);
+}

--- a/frontend/src/lib/workflowRoutes.ts
+++ b/frontend/src/lib/workflowRoutes.ts
@@ -1,0 +1,137 @@
+export type RouteId = "1" | "2" | "3";
+
+export type WorkflowStep = {
+  step: number;
+  tab: string;
+  label: string;
+  icon: string;
+  href: string;
+};
+
+export const ALL_STEPS: WorkflowStep[] = [
+  { step: 1, tab: "job-preferences", label: "Role Preferences", icon: "🎯", href: "/job-preferences" },
+  { step: 2, tab: "candidate-profile", label: "Your Resume", icon: "📄", href: "/resume" },
+  { step: 3, tab: "personality", label: "Personality", icon: "🧠", href: "/personality" },
+  { step: 4, tab: "job-descriptions", label: "Role Search", icon: "🔎", href: "/job-descriptions" },
+  { step: 5, tab: "gap-analysis", label: "Gap Analysis", icon: "🧩", href: "/gap-analysis" },
+  { step: 6, tab: "painpoint-match", label: "Pain Point Match", icon: "🔗", href: "/painpoint-match" },
+  { step: 7, tab: "company-research", label: "Company Research", icon: "🏢", href: "/company-research" },
+  { step: 8, tab: "decision-makers", label: "Decision Makers", icon: "👤", href: "/find-contact" },
+  { step: 9, tab: "offer", label: "Offer", icon: "✨", href: "/offer" },
+  { step: 10, tab: "bio-page", label: "Bio Page", icon: "🌐", href: "/bio-page" },
+  { step: 11, tab: "apply", label: "Apply", icon: "✅", href: "/apply" },
+  { step: 12, tab: "campaign", label: "Campaign", icon: "📧", href: "/campaign" },
+];
+
+/** Route 1: full job-search path (roles → gaps → match → research …) */
+export const ROUTE1_STEP_ORDER = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+/** Routes 2 & 3: skip role search; research before pain-point match */
+export const ROUTE23_STEP_ORDER = [1, 2, 3, 7, 6, 8, 9, 10, 11, 12];
+
+export const ROUTE_DEFINITIONS: Array<{
+  id: RouteId;
+  badge: string;
+  title: string;
+  subtitle: string;
+  strategy: string;
+  icon: string;
+  difficulty: string;
+  accent: string;
+}> = [
+  {
+    id: "1",
+    badge: "Route 1",
+    title: "Open Roles",
+    subtitle: "They are actively hiring for your type of role",
+    strategy: "Direct outreach tied to posted roles. Easiest path.",
+    icon: "📋",
+    difficulty: "Easiest",
+    accent: "border-emerald-500/40 bg-emerald-600/10 ring-emerald-500/30",
+  },
+  {
+    id: "2",
+    badge: "Route 2",
+    title: "Need Exists",
+    subtitle: "They need someone like you but have not posted it yet",
+    strategy: "Lead with a free insight or mini-deliverable.",
+    icon: "💡",
+    difficulty: "Moderate",
+    accent: "border-blue-500/40 bg-blue-600/10 ring-blue-500/30",
+  },
+  {
+    id: "3",
+    badge: "Route 3",
+    title: "Hidden Market",
+    subtitle: "No open role. You are creating the need.",
+    strategy: "Lead with substantial free work upfront.",
+    icon: "🧭",
+    difficulty: "Hardest",
+    accent: "border-purple-500/40 bg-purple-600/10 ring-purple-500/30",
+  },
+];
+
+export const STORAGE_ACTIVE_ROUTE = "rf_active_route";
+
+export function getActiveRoute(): RouteId | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(STORAGE_ACTIVE_ROUTE);
+    if (raw === "1" || raw === "2" || raw === "3") return raw;
+    // Migrate legacy single positioning level
+    const d100 = JSON.parse(localStorage.getItem("rf_dream100") || "null");
+    const level = String(d100?.positioningLevel || d100?.selectedRoute || "").trim();
+    if (level === "1" || level === "2" || level === "3") return level as RouteId;
+  } catch {}
+  return null;
+}
+
+export function setActiveRoute(route: RouteId) {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(STORAGE_ACTIVE_ROUTE, route);
+  try {
+    const d100 = JSON.parse(localStorage.getItem("rf_dream100") || "{}");
+    localStorage.setItem("rf_dream100", JSON.stringify({ ...d100, selectedRoute: route, positioningLevel: route }));
+  } catch {}
+  window.dispatchEvent(new CustomEvent("rf-route-changed", { detail: route }));
+}
+
+export function getStepsForRoute(route: RouteId | null): WorkflowStep[] {
+  const order = route === "1" ? ROUTE1_STEP_ORDER : route ? ROUTE23_STEP_ORDER : ROUTE1_STEP_ORDER;
+  const byStep = new Map(ALL_STEPS.map((s) => [s.step, s]));
+  return order.map((n) => byStep.get(n)).filter(Boolean) as WorkflowStep[];
+}
+
+export function isStepVisibleForRoute(step: number, route: RouteId | null): boolean {
+  if (!route) return true;
+  const order = route === "1" ? ROUTE1_STEP_ORDER : ROUTE23_STEP_ORDER;
+  return order.includes(step);
+}
+
+export function pathForStep(step: number): string | null {
+  return ALL_STEPS.find((s) => s.step === step)?.href || null;
+}
+
+/** Visual grid positions in snake order (display index 0 → first stone). */
+export const SNAKE_POSITIONS: Array<{ top: number; left: number }> = [
+  { top: 40, left: 20 },
+  { top: 40, left: 210 },
+  { top: 40, left: 400 },
+  { top: 40, left: 590 },
+  { top: 160, left: 590 },
+  { top: 160, left: 400 },
+  { top: 160, left: 210 },
+  { top: 160, left: 20 },
+  { top: 320, left: 20 },
+  { top: 320, left: 210 },
+  { top: 320, left: 400 },
+  { top: 320, left: 590 },
+];
+
+/** Steps skipped on routes 2 & 3 (role search + gap analysis). */
+export const ROUTE23_SKIPPED_STEPS = [4, 5];
+
+export function isStepSkippedForRoute(step: number, route: RouteId | null): boolean {
+  if (!route || route === "1") return false;
+  return ROUTE23_SKIPPED_STEPS.includes(step);
+}


### PR DESCRIPTION
## Summary
- Add Route 1/2/3 picker on the dashboard (Open Roles, Need Exists, Hidden Market) with route-filtered workflow steps and navbar
- Routes 2 and 3 skip Role Search and Gap Analysis; guard those pages and reorder stones sequentially
- Move strongest career result to Resume and free deliverable to Offer; wire through campaign context
- Add collapsible Overview panel, job prefs validation, and Dream 100 Targeting engine (criteria, channels, scoring, sample list)

## Test plan
- [ ] Pick Route 1 on dashboard: all 12 steps visible; Roles and Gaps accessible
- [ ] Pick Route 2 or 3: Roles/Gaps redirect to dashboard; Research before Pain Point Match in nav
- [ ] Resume: career result auto-fills from metrics; saves to rf_career_result
- [ ] Offer: free deliverable saves; case study quick inserts go to focused field
- [ ] Job prefs: validation errors block save; Dream 100 Targeting generates plan
- [ ] Overview panel shows route, role, ideal company, career result, deliverable on key pages

Made with [Cursor](https://cursor.com)